### PR TITLE
feat: add gemma3:270m local model via Ollama on host machine

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,3 +26,12 @@ OPENROUTER_API_KEY=       # only needed for free models
 # ── App settings ──────────────────────────────────────────────────────────────
 DEFAULT_DAILY_LIMIT=50
 MAX_FILE_SIZE_MB=10
+
+# ── Ollama (local / remote models) ───────────────────────────────────────────
+# URL of the Ollama instance reachable from inside Docker.
+# Host machine (default): http://host.docker.internal:11434
+# Remote server:          http://<ollama-host>:11434
+# Docker Compose service: http://ollama:11434
+OLLAMA_BASE_URL=http://host.docker.internal:11434
+# Comma-separated list of model IDs pulled in Ollama (must match litellm/config.yaml model_name values)
+OLLAMA_MODEL_IDS=gemma3:270m

--- a/.env.example
+++ b/.env.example
@@ -30,8 +30,7 @@ MAX_FILE_SIZE_MB=10
 # ── Ollama (local / remote models) ───────────────────────────────────────────
 # URL of the Ollama instance reachable from inside Docker.
 # Host machine (default): http://host.docker.internal:11434
-# Remote server:          http://<ollama-host>:11434
-# Docker Compose service: http://ollama:11434
+# Remote server (HTTPS):  https://ollama.example.com
 OLLAMA_BASE_URL=http://host.docker.internal:11434
 # Comma-separated list of model IDs pulled in Ollama (must match litellm/config.yaml model_name values)
 OLLAMA_MODEL_IDS=gemma3:270m

--- a/README.md
+++ b/README.md
@@ -180,6 +180,54 @@ Get a free OpenRouter key at [openrouter.ai](https://openrouter.ai).
 
 ---
 
+## Ollama (local & remote models)
+
+Ollama lets you run open-weight models locally or on any server you control — no cloud API key needed.
+
+### Prerequisites
+
+- [Ollama](https://ollama.com) installed and running (separate from Docker)
+- The model pulled: `ollama pull gemma3:270m`
+
+> **Note:** Ollama is **not** a Docker Compose service in this project. It runs as a standalone process on the host or a remote machine. Docker containers reach the host via `host.docker.internal:11434` (the default).
+
+### Configuration
+
+Add the following to your `.env`:
+
+```bash
+# URL of the Ollama instance, as seen from inside Docker
+OLLAMA_BASE_URL=http://host.docker.internal:11434   # host machine (default)
+# OLLAMA_BASE_URL=http://192.168.1.50:11434         # remote server
+# OLLAMA_BASE_URL=http://ollama:11434               # if running as a Docker service
+
+# Comma-separated model IDs — must match model_name values in litellm/config.yaml
+OLLAMA_MODEL_IDS=gemma3:270m
+```
+
+### Remote Ollama
+
+To point the app at an Ollama instance on another machine:
+
+1. Start Ollama on the remote host with `OLLAMA_HOST=0.0.0.0 ollama serve`
+2. Set `OLLAMA_BASE_URL=http://<remote-ip>:11434` in `.env`
+3. Rebuild: `docker compose up -d --build app litellm`
+
+### Adding more Ollama models
+
+1. Pull the model: `ollama pull <model>`
+2. Add an entry to `litellm/config.yaml`:
+   ```yaml
+   - model_name: <model>
+     litellm_params:
+       model: ollama/<model>
+       api_base: os.environ/OLLAMA_BASE_URL
+   ```
+3. Add the model name to `OLLAMA_MODEL_IDS` in `.env` (comma-separated)
+4. Rebuild: `docker compose up -d --build app litellm`
+
+---
+
 ## Prompt Security
 
 ### Setup

--- a/README.md
+++ b/README.md
@@ -198,8 +198,7 @@ Add the following to your `.env`:
 ```bash
 # URL of the Ollama instance, as seen from inside Docker
 OLLAMA_BASE_URL=http://host.docker.internal:11434   # host machine (default)
-# OLLAMA_BASE_URL=http://192.168.1.50:11434         # remote server
-# OLLAMA_BASE_URL=http://ollama:11434               # if running as a Docker service
+# OLLAMA_BASE_URL=https://ollama.example.com        # remote server (HTTPS, no port)
 
 # Comma-separated model IDs — must match model_name values in litellm/config.yaml
 OLLAMA_MODEL_IDS=gemma3:270m
@@ -207,10 +206,10 @@ OLLAMA_MODEL_IDS=gemma3:270m
 
 ### Remote Ollama
 
-To point the app at an Ollama instance on another machine:
+Remote Ollama should be placed behind a reverse proxy (nginx, Caddy, etc.) that terminates TLS. The app then connects over standard HTTPS with no custom port:
 
-1. Start Ollama on the remote host with `OLLAMA_HOST=0.0.0.0 ollama serve`
-2. Set `OLLAMA_BASE_URL=http://<remote-ip>:11434` in `.env`
+1. Deploy Ollama behind a reverse proxy at `https://ollama.example.com`
+2. Set `OLLAMA_BASE_URL=https://ollama.example.com` in `.env`
 3. Rebuild: `docker compose up -d --build app litellm`
 
 ### Adding more Ollama models

--- a/app/main.py
+++ b/app/main.py
@@ -102,7 +102,12 @@ _PROVIDER_URLS = {
 }
 
 
+_OLLAMA_MODEL_IDS = {s.strip() for s in os.getenv("OLLAMA_MODEL_IDS", "").split(",") if s.strip()}
+
+
 def _detect_provider(model_id: str) -> str:
+    if model_id in _OLLAMA_MODEL_IDS:
+        return "ollama"
     m = model_id.lower()
     if m.startswith(("gpt-", "o1", "o3", "o4")):
         return "openai"
@@ -118,6 +123,8 @@ def _detect_provider(model_id: str) -> str:
 def _model_meta(model_id: str) -> dict:
     """Return category, provider, and required key info for a model."""
     provider = _detect_provider(model_id)
+    if provider == "ollama":
+        return {"category": "local", "provider": "Ollama", "requires_key": None}
     is_free = model_id.lower().endswith(":free")
     return {
         "category": "free" if is_free else "paid",
@@ -377,7 +384,7 @@ async def models(current_user: User = Depends(get_current_user)):
     for m in available:
         meta = _model_meta(m["id"])
         provider = _detect_provider(m["id"])
-        key_set = provider in user_providers or provider in shared_providers
+        key_set = provider == "ollama" or provider in user_providers or provider in shared_providers
         enriched.append({**m, **meta, "key_set": key_set})
 
     return {"models": enriched, "fallback": not bool(live)}

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -1994,8 +1994,9 @@ reply = await client.chat.completions.create(
     }
 
     // Group models by category
-    const free = models.filter(m => m.category === 'free');
-    const paid = models.filter(m => m.category !== 'free');
+    const local = models.filter(m => m.category === 'local');
+    const free  = models.filter(m => m.category === 'free');
+    const paid  = models.filter(m => m.category !== 'free' && m.category !== 'local');
 
     let firstSelectable = null;
 
@@ -2020,6 +2021,7 @@ reply = await client.chat.completions.create(
       modelSelect.appendChild(grp);
     }
 
+    addGroup('Local Models (Ollama)', local);
     addGroup('Free Models', free);
     addGroup('Paid Models', paid);
 

--- a/litellm/config.yaml
+++ b/litellm/config.yaml
@@ -120,11 +120,14 @@ model_list:
       model: openrouter/sourceful/riverflow-v2-fast-preview
       api_key: os.environ/OPENROUTER_API_KEY
 
-  # ── Local models via Ollama (host machine) ───────────────────────────────
+  # ── Local models via Ollama ──────────────────────────────────────────────
+  # Set OLLAMA_BASE_URL in .env to point to your Ollama instance.
+  # Default: http://host.docker.internal:11434 (Ollama on the host Mac/Linux machine)
+  # Remote:  http://<ollama-host>:11434
   - model_name: gemma3:270m
     litellm_params:
       model: ollama/gemma3:270m
-      api_base: http://host.docker.internal:11434
+      api_base: os.environ/OLLAMA_BASE_URL
 
 litellm_settings:
   drop_params: true

--- a/litellm/config.yaml
+++ b/litellm/config.yaml
@@ -120,6 +120,12 @@ model_list:
       model: openrouter/sourceful/riverflow-v2-fast-preview
       api_key: os.environ/OPENROUTER_API_KEY
 
+  # ── Local models via Ollama (host machine) ───────────────────────────────
+  - model_name: gemma3:270m
+    litellm_params:
+      model: ollama/gemma3:270m
+      api_base: http://host.docker.internal:11434
+
 litellm_settings:
   drop_params: true
   request_timeout: 60


### PR DESCRIPTION
Adds the OLLAMA_MODEL_IDS env var pattern so any Ollama model served on the host can be added by name without API keys. Registers gemma3:270m in LiteLLM with api_base pointing to host.docker.internal:11434.

Frontend model selector gains a "Local Models (Ollama)" group above Free.