### PR TITLE
fix: respect skip_ps in gateway mode for compare view

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1162,7 +1162,7 @@ async def chat_stream(
         ]
 
         # ── Gateway mode: route through PS proxy, skip explicit scanning ───────
-        if ps_gw_gemini:
+        if ps_gw_gemini and not skip_ps:
             system_parts, contents = [], []
             for msg in payload:
                 role = msg.get('role', 'user')
@@ -1206,7 +1206,7 @@ async def chat_stream(
             yield f"data: {json.dumps({'type': 'done', 'model': model, 'session_id': session_id, 'ps_scanned': True, 'ps_action': 'gateway', 'ps_violations': [], 'messages_today': today_used, 'daily_limit': current_user.daily_message_limit, 'prompt_tokens': 0, 'completion_tokens': 0, 'total_tokens': 0})}\n\n"
             return
 
-        if ps_gw_anthropic:
+        if ps_gw_anthropic and not skip_ps:
             anthropic_messages = []
             system_text = ""
             for msg in payload:
@@ -1277,7 +1277,7 @@ async def chat_stream(
             yield f"data: {json.dumps({'type': 'done', 'model': model, 'session_id': session_id, 'ps_scanned': True, 'ps_action': 'gateway', 'ps_violations': [], 'messages_today': today_used, 'daily_limit': current_user.daily_message_limit, 'prompt_tokens': prompt_tokens, 'completion_tokens': completion_tokens, 'total_tokens': total_tokens})}\n\n"
             return
 
-        if ps_gw_client:
+        if ps_gw_client and not skip_ps:
             try:
                 prompt_tokens = estimate_message_tokens(payload, model=model)
                 stream = await ps_gw_client.chat.completions.create(


### PR DESCRIPTION
## Summary
- All three PS gateway paths (Gemini, Anthropic, OpenAI-compat/Perplexity) were ignoring `skip_ps`, routing the raw LLM side through the PS gateway
- In compare mode both columns showed "Blocked due to policy violations" even though the right column should bypass PS entirely
- Fix: add `and not skip_ps` to each gateway entry condition so the raw side falls through to the direct LiteLLM call

## Test plan
- [x] Enable compare mode with gateway PS mode configured
- [x] Send a message that would be blocked by PS policy
- [x] Left column (With PS) should show blocked
- [x] Right column (Without PS / raw LLM) should return the LLM response unblocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)