### PR TITLE
docs/security: add shared app skill and remediate findings

### DIFF
--- a/.codex/skills/homegrown-ai-app-demo/SKILL.md
+++ b/.codex/skills/homegrown-ai-app-demo/SKILL.md
@@ -17,6 +17,7 @@ Use this skill for project-specific app operations in the HomeGrown AI App Demo 
   - Chat UI: `http://localhost:9000`
   - Admin UI: `http://localhost:9000/admin`
   - LiteLLM proxy: `http://localhost:4000`
+- If host port `4000` is occupied, set `LITELLM_HOST_PORT=4001` in `.env`; keep `LITELLM_BASE_URL=http://litellm:4000` for app-to-proxy traffic inside Docker.
 - Default admin bootstrap is read from `.env`; current defaults are `admin@example.com` / `admin`.
 - Local secrets and provider keys belong in `.env`, which is gitignored.
 - Repo-level LiteLLM model routing lives in `litellm/config.yaml`.
@@ -60,6 +61,13 @@ Ask for the missing details before wiring a custom endpoint:
 - Whether the endpoint is OpenAI-compatible
 
 For OpenAI-compatible endpoints, prefer adding environment variables to `.env` and a model entry to `litellm/config.yaml`; never hardcode API keys in repo files. After changing LiteLLM config, restart `litellm` and `app`, refresh models, then test a minimal chat request if a key is available.
+
+For the project’s local OpenAI-compatible test server, use:
+
+- Host URL: `http://localhost:8081/v1`
+- Docker URL: `http://host.docker.internal:8081/v1`
+- Current model ID: `huggingface/Qwen3VL-8B-Instruct-F16`
+- Env vars: `LOCAL_OPENAI_BASE_URL`, `LOCAL_OPENAI_API_KEY`, `LOCAL_OPENAI_MODEL_IDS`
 
 ### Debug
 

--- a/.codex/skills/homegrown-ai-app-demo/SKILL.md
+++ b/.codex/skills/homegrown-ai-app-demo/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: homegrown-ai-app-demo
+description: Use when working on, running, stopping, verifying, debugging, or configuring the HomeGrown AI App Demo project, including its Docker Compose stack, FastAPI app, PostgreSQL database, LiteLLM proxy, Prompt Security settings, model cache, provider keys, or custom inference endpoints.
+---
+
+# HomeGrown AI App Demo
+
+## Overview
+
+Use this skill for project-specific app operations in the HomeGrown AI App Demo repository. It captures the known Docker Compose workflow, verification checks, and inference configuration points for this repo.
+
+## Project Facts
+
+- App directory: the repository root containing `docker-compose.yml`, `app/`, and `litellm/`
+- Main services: `app`, `db`, `litellm`
+- URLs:
+  - Chat UI: `http://localhost:9000`
+  - Admin UI: `http://localhost:9000/admin`
+  - LiteLLM proxy: `http://localhost:4000`
+- Default admin bootstrap is read from `.env`; current defaults are `admin@example.com` / `admin`.
+- Local secrets and provider keys belong in `.env`, which is gitignored.
+- Repo-level LiteLLM model routing lives in `litellm/config.yaml`.
+
+## Helper Script
+
+Prefer the bundled script for routine operations:
+
+```bash
+bash .codex/skills/homegrown-ai-app-demo/scripts/manage.sh status
+bash .codex/skills/homegrown-ai-app-demo/scripts/manage.sh start
+bash .codex/skills/homegrown-ai-app-demo/scripts/manage.sh stop
+bash .codex/skills/homegrown-ai-app-demo/scripts/manage.sh verify
+bash .codex/skills/homegrown-ai-app-demo/scripts/manage.sh refresh-models
+```
+
+Run the helper from anywhere inside the repo. If the repo cannot be discovered from the current directory or script location, set `HOMEGROWN_AI_APP_DIR=/path/to/homegrown-ai-app-demo`.
+
+## Common Workflows
+
+### Start or Restart
+
+1. Check for dirty work before edits: `git status --short`.
+2. Ensure `.env` exists. If missing, create it from `.env.example` with generated development secrets; do not commit `.env`.
+3. Run `docker compose up -d --build`.
+4. Wait for LiteLLM to finish first-run migrations if needed.
+5. Refresh the app model cache with `POST /admin/refresh-models`.
+6. Verify with `docker compose ps`, `GET /health`, `GET /`, `GET /admin`, and authenticated `GET /models`.
+
+### Stop
+
+Run `docker compose stop`, then verify `docker compose ps` shows no project containers running.
+
+### Configure Inference
+
+Ask for the missing details before wiring a custom endpoint:
+
+- Base URL
+- Auth method and API key/header
+- Model ID exposed by the endpoint
+- Whether the endpoint is OpenAI-compatible
+
+For OpenAI-compatible endpoints, prefer adding environment variables to `.env` and a model entry to `litellm/config.yaml`; never hardcode API keys in repo files. After changing LiteLLM config, restart `litellm` and `app`, refresh models, then test a minimal chat request if a key is available.
+
+### Debug
+
+- App logs: `docker compose logs --no-color --tail=120 app`
+- LiteLLM logs: `docker compose logs --no-color --tail=160 litellm`
+- DB logs: `docker compose logs --no-color --tail=120 db`
+- Health: `curl -sS http://localhost:9000/health | python3 -m json.tool`
+- LiteLLM models:
+  `curl -sS http://localhost:4000/v1/models -H "Authorization: Bearer $(grep '^LITELLM_MASTER_KEY=' .env | cut -d= -f2-)"`
+
+## Verification Rule
+
+Before saying the app is running, stopped, fixed, or configured, run fresh verification in the current turn and report the actual output state. Use `superpowers:verification-before-completion` when making completion claims.

--- a/.codex/skills/homegrown-ai-app-demo/agents/openai.yaml
+++ b/.codex/skills/homegrown-ai-app-demo/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Homegrown AI App Demo"
+  short_description: "Manage this repo app stack"
+  default_prompt: "Use $homegrown-ai-app-demo to start, stop, verify, or configure the HomeGrown AI app demo."

--- a/.codex/skills/homegrown-ai-app-demo/scripts/manage.sh
+++ b/.codex/skills/homegrown-ai-app-demo/scripts/manage.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ACTION="${1:-status}"
+
+usage() {
+  cat <<'USAGE'
+Usage: manage.sh start|stop|restart|status|health|refresh-models|verify|logs [service]
+
+Environment:
+  HOMEGROWN_AI_APP_DIR  Override app directory.
+  TAIL                  Override log tail line count for logs.
+USAGE
+}
+
+looks_like_app_dir() {
+  local dir="$1"
+  [[ -f "$dir/docker-compose.yml" && -d "$dir/app" && -d "$dir/litellm" ]]
+}
+
+find_app_dir() {
+  local dir
+
+  if [[ -n "${HOMEGROWN_AI_APP_DIR:-}" ]]; then
+    if looks_like_app_dir "$HOMEGROWN_AI_APP_DIR"; then
+      printf "%s\n" "$HOMEGROWN_AI_APP_DIR"
+      return
+    fi
+    printf "HOMEGROWN_AI_APP_DIR does not look like this repo: %s\n" "$HOMEGROWN_AI_APP_DIR" >&2
+    exit 1
+  fi
+
+  dir="$PWD"
+  while [[ "$dir" != "/" ]]; do
+    if looks_like_app_dir "$dir"; then
+      printf "%s\n" "$dir"
+      return
+    fi
+    dir="$(dirname "$dir")"
+  done
+
+  dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+  while [[ "$dir" != "/" ]]; do
+    if looks_like_app_dir "$dir"; then
+      printf "%s\n" "$dir"
+      return
+    fi
+    dir="$(dirname "$dir")"
+  done
+
+  cat >&2 <<'ERROR'
+Could not find the HomeGrown AI App Demo repo root.
+Run from inside the repo or set HOMEGROWN_AI_APP_DIR=/path/to/homegrown-ai-app-demo.
+ERROR
+  exit 1
+}
+
+if [[ "$ACTION" == "help" || "$ACTION" == "--help" || "$ACTION" == "-h" ]]; then
+  usage
+  exit 0
+fi
+
+APP_DIR="$(find_app_dir)"
+cd "$APP_DIR"
+
+require_docker() {
+  if ! docker info >/dev/null 2>&1; then
+    cat >&2 <<'ERROR'
+Docker is not reachable. Start Docker Desktop or the Docker daemon, then rerun this command.
+ERROR
+    exit 1
+  fi
+}
+
+env_value() {
+  local key="$1"
+  if [[ -f .env ]]; then
+    sed -n "s/^${key}=//p" .env | tail -n 1
+  fi
+}
+
+json_value() {
+  local field="$1"
+  python3 -c "import json,sys; print(json.load(sys.stdin).get('${field}', ''))"
+}
+
+admin_token() {
+  local email password response
+  email="$(env_value ADMIN_EMAIL)"
+  password="$(env_value ADMIN_PASSWORD)"
+  email="${email:-admin@example.com}"
+  password="${password:-admin}"
+
+  response="$(
+    curl -fsS http://localhost:9000/auth/login \
+      -H "Content-Type: application/json" \
+      -d "{\"email\":\"${email}\",\"password\":\"${password}\"}"
+  )"
+  printf "%s" "$response" | json_value access_token
+}
+
+health() {
+  curl -fsS http://localhost:9000/health | python3 -m json.tool
+}
+
+refresh_models() {
+  local token
+  token="$(admin_token)"
+  curl -fsS -X POST http://localhost:9000/admin/refresh-models \
+    -H "Authorization: Bearer ${token}" | python3 -m json.tool
+}
+
+model_count() {
+  local token
+  token="$(admin_token)"
+  curl -fsS http://localhost:9000/models \
+    -H "Authorization: Bearer ${token}" |
+    python3 -c 'import json,sys; data=json.load(sys.stdin); print(f"{len(data.get(\"models\", []))} models; fallback={data.get(\"fallback\")}")'
+}
+
+http_head() {
+  local url="$1"
+  curl -i -sS "$url" | sed -n '1,6p'
+}
+
+case "$ACTION" in
+  start)
+    require_docker
+    docker compose up -d --build
+    ;;
+  stop)
+    require_docker
+    docker compose stop
+    docker compose ps
+    ;;
+  restart)
+    require_docker
+    docker compose up -d --build
+    ;;
+  status)
+    require_docker
+    docker compose ps
+    ;;
+  health)
+    health
+    ;;
+  refresh-models)
+    refresh_models
+    ;;
+  verify)
+    require_docker
+    docker compose ps
+    printf "\nhealth:\n"
+    health
+    printf "\nroot status:\n"
+    http_head "http://localhost:9000/"
+    printf "\nadmin status:\n"
+    http_head "http://localhost:9000/admin"
+    printf "\nauthenticated model count:\n"
+    model_count
+    ;;
+  logs)
+    require_docker
+    service="${2:-app}"
+    tail_lines="${TAIL:-120}"
+    docker compose logs --no-color --tail="$tail_lines" "$service"
+    ;;
+  *)
+    usage
+    exit 2
+    ;;
+esac

--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,7 @@ ADMIN_PASSWORD=admin
 
 # ── LiteLLM proxy ─────────────────────────────────────────────────────────────
 LITELLM_BASE_URL=http://litellm:4000
+LITELLM_HOST_PORT=4000
 LITELLM_MASTER_KEY=change_me_litellm_key
 
 # ── LLM provider keys (used by LiteLLM) ──────────────────────────────────────
@@ -34,3 +35,11 @@ MAX_FILE_SIZE_MB=10
 OLLAMA_BASE_URL=http://host.docker.internal:11434
 # Comma-separated list of model IDs pulled in Ollama (must match litellm/config.yaml model_name values)
 OLLAMA_MODEL_IDS=gemma3:270m
+
+# ── Local OpenAI-compatible inference endpoint ───────────────────────────────
+# URL of an OpenAI-style local server reachable from inside Docker.
+LOCAL_OPENAI_BASE_URL=http://host.docker.internal:8081/v1
+# Many local OpenAI-compatible servers ignore this value, but LiteLLM expects one.
+LOCAL_OPENAI_API_KEY=local-dev-key
+# Comma-separated model IDs that should appear as Local Models in the UI.
+LOCAL_OPENAI_MODEL_IDS=huggingface/Qwen3VL-8B-Instruct-F16

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 ### Security
 - Remediate code-scanning findings for Prompt Security URL validation, client error handling, API key hashing, CDN integrity, token-count logging, and the container runtime user — @david.abutbul
 - Normalize legacy public `http://` Prompt Security tenant URLs to HTTPS during startup and disable PS for unsafe legacy tenant URLs so upgrades soft-fail instead of breaking chat, public API, or file sanitization flows — @david.abutbul
-- Document that existing instances must update or recreate Prompt Security tenants using `http://`, localhost, `.local`, private-IP, or reserved-network URLs because these values are intentionally rejected to prevent SSRF and local-network exposure — @david.abutbul
+- Document that existing instances must update or recreate Prompt Security tenants using `http://`, localhost, `.local`, private-IP, or reserved-network URLs because these values are intentionally rejected as part of CodeQL alert 12 (`py/full-ssrf`) remediation — @david.abutbul
 
 ## [2026-05-03]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,11 @@
 
 ### Changed
 - Make the LiteLLM host port configurable for local environments with an existing proxy on port 4000 — @david.abutbul
+- Require provider keys for all non-local model metadata, including OpenRouter `:free` entries, so the UI disables models that would fail without configured credentials — @david.abutbul
 
 ### Security
 - Remediate code-scanning findings for Prompt Security URL validation, client error handling, API key hashing, CDN integrity, token-count logging, and the container runtime user — @david.abutbul
+- Normalize legacy public `http://` Prompt Security tenant URLs to HTTPS during startup and disable PS for unsafe legacy tenant URLs so upgrades soft-fail instead of breaking chat, public API, or file sanitization flows — @david.abutbul
 
 ## [2026-05-03]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [2026-05-04]
+### Added
+- Shared Codex skill for managing the local demo app stack and inference setup — @david.abutbul
+
 ## [2026-05-03]
 ### Added
 - Demo storytelling: severity badges (HIGH/MEDIUM), attacker-goal, and SE talking-point on every scenario card

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### Security
 - Remediate code-scanning findings for Prompt Security URL validation, client error handling, API key hashing, CDN integrity, token-count logging, and the container runtime user — @david.abutbul
 - Normalize legacy public `http://` Prompt Security tenant URLs to HTTPS during startup and disable PS for unsafe legacy tenant URLs so upgrades soft-fail instead of breaking chat, public API, or file sanitization flows — @david.abutbul
+- Document that existing instances must update or recreate Prompt Security tenants using `http://`, localhost, `.local`, private-IP, or reserved-network URLs because these values are intentionally rejected to prevent SSRF and local-network exposure — @david.abutbul
 
 ## [2026-05-03]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 ## [2026-05-04]
 ### Added
 - Shared Codex skill for managing the local demo app stack and inference setup — @david.abutbul
+- Local OpenAI-compatible inference endpoint configuration for Docker-hosted LiteLLM testing — @david.abutbul
+
+### Changed
+- Make the LiteLLM host port configurable for local environments with an existing proxy on port 4000 — @david.abutbul
 
 ### Security
 - Remediate code-scanning findings for Prompt Security URL validation, client error handling, API key hashing, CDN integrity, token-count logging, and the container runtime user — @david.abutbul

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 ### Added
 - Shared Codex skill for managing the local demo app stack and inference setup — @david.abutbul
 
+### Security
+- Remediate code-scanning findings for Prompt Security URL validation, client error handling, API key hashing, CDN integrity, token-count logging, and the container runtime user — @david.abutbul
+
 ## [2026-05-03]
 ### Added
 - Demo storytelling: severity badges (HIGH/MEDIUM), attacker-goal, and SE talking-point on every scenario card

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,4 +3,6 @@ WORKDIR /app
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 COPY app/ .
+RUN useradd --system --create-home --shell /usr/sbin/nologin appuser
+USER appuser
 CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ ADMIN_PASSWORD=your_admin_password
 
 # ── LiteLLM proxy ─────────────────────────────────────────────────────────────
 LITELLM_BASE_URL=http://litellm:4000
+LITELLM_HOST_PORT=4000
 # Generate with: python -c "import secrets; print(secrets.token_hex(32))"
 LITELLM_MASTER_KEY=your_litellm_master_key
 
@@ -172,11 +173,16 @@ Models are configured in `litellm/config.yaml`. By default the following are ena
 | `meta-llama/llama-3.1-8b-instruct:free`                    | OpenRouter | **Free** — requires `OPENROUTER_API_KEY` |
 | `nvidia/nemotron-nano-9b-v2:free`                          | OpenRouter | **Free** — requires `OPENROUTER_API_KEY` |
 | `mistralai/mistral-7b-instruct:free`                       | OpenRouter | **Free** — requires `OPENROUTER_API_KEY` |
+| `huggingface/Qwen3VL-8B-Instruct-F16`                      | Local OpenAI-compatible | Uses `LOCAL_OPENAI_BASE_URL` |
 
 
 Get a free OpenRouter key at [openrouter.ai](https://openrouter.ai).
 
 > **Note:** Per-user LLM override settings are hidden from the UI by default. If you need them later, set `SHOW_LLM_KEY_SETTINGS=true` and rebuild the app.
+
+If another service already uses host port `4000`, set `LITELLM_HOST_PORT=4001`
+in `.env`. The app still talks to LiteLLM through Docker at
+`LITELLM_BASE_URL=http://litellm:4000`.
 
 ---
 
@@ -224,6 +230,23 @@ Remote Ollama should be placed behind a reverse proxy (nginx, Caddy, etc.) that 
    ```
 3. Add the model name to `OLLAMA_MODEL_IDS` in `.env` (comma-separated)
 4. Rebuild: `docker compose up -d --build app litellm`
+
+---
+
+## Local OpenAI-compatible endpoint
+
+For local servers that expose OpenAI-style `/v1/models` and `/v1/chat/completions`
+endpoints, add these values to `.env`:
+
+```bash
+LOCAL_OPENAI_BASE_URL=http://host.docker.internal:8081/v1
+LOCAL_OPENAI_API_KEY=local-dev-key
+LOCAL_OPENAI_MODEL_IDS=huggingface/Qwen3VL-8B-Instruct-F16
+```
+
+The default `litellm/config.yaml` includes that model ID. For a different local
+model, update both `model_name` / `litellm_params.model` in `litellm/config.yaml`
+and `LOCAL_OPENAI_MODEL_IDS` in `.env`, then rebuild `app` and `litellm`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ and `LOCAL_OPENAI_MODEL_IDS` in `.env`, then rebuild `app` and `litellm`.
 ### Setup
 
 1. Log in as admin and go to **PS Tenants** in the admin dashboard.
-2. Create a tenant with your PS `base_url` (API mode) and optionally a `gateway_url` (Gateway mode).
+2. Create a tenant with your PS `base_url` (API mode) and optionally a `gateway_url` (Gateway mode). Both URLs must use `https://` and a public hostname; localhost, `.local`, private IPs, and reserved networks are rejected to prevent SSRF or local-network routing through tenant configuration.
 3. In ⚙ **Settings → Prompt Security**, select the tenant, enter your PS App ID, and choose API or Gateway mode.
 
 ### Modes
@@ -268,6 +268,8 @@ and `LOCAL_OPENAI_MODEL_IDS` in `.env`, then rebuild `app` and `litellm`.
 
 
 > **Important:** Each PS tenant has its own App ID. If you switch tenants, you must re-enter the App ID for the new tenant. The previous App ID is automatically cleared on tenant change.
+
+> **Upgrade note:** Existing instances that already contain Prompt Security tenants with `http://`, localhost, `.local`, private-IP, or reserved-network URLs must update or recreate those tenants with public HTTPS URLs. These legacy values are intentionally no longer supported because tenant URLs are used by server-side PS calls and unsafe targets can expose internal services.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ and `LOCAL_OPENAI_MODEL_IDS` in `.env`, then rebuild `app` and `litellm`.
 ### Setup
 
 1. Log in as admin and go to **PS Tenants** in the admin dashboard.
-2. Create a tenant with your PS `base_url` (API mode) and optionally a `gateway_url` (Gateway mode). Both URLs must use `https://` and a public hostname; localhost, `.local`, private IPs, and reserved networks are rejected to prevent SSRF or local-network routing through tenant configuration.
+2. Create a tenant with your PS `base_url` (API mode) and optionally a `gateway_url` (Gateway mode). Both URLs must use `https://` and a public hostname; localhost, `.local`, private IPs, and reserved networks are rejected to remediate CodeQL alert 12 (`py/full-ssrf`) where tenant-controlled URLs were used by server-side Prompt Security requests.
 3. In ⚙ **Settings → Prompt Security**, select the tenant, enter your PS App ID, and choose API or Gateway mode.
 
 ### Modes
@@ -269,7 +269,7 @@ and `LOCAL_OPENAI_MODEL_IDS` in `.env`, then rebuild `app` and `litellm`.
 
 > **Important:** Each PS tenant has its own App ID. If you switch tenants, you must re-enter the App ID for the new tenant. The previous App ID is automatically cleared on tenant change.
 
-> **Upgrade note:** Existing instances that already contain Prompt Security tenants with `http://`, localhost, `.local`, private-IP, or reserved-network URLs must update or recreate those tenants with public HTTPS URLs. These legacy values are intentionally no longer supported because tenant URLs are used by server-side PS calls and unsafe targets can expose internal services.
+> **Upgrade note:** Existing instances that already contain Prompt Security tenants with `http://`, localhost, `.local`, private-IP, or reserved-network URLs must update or recreate those tenants with public HTTPS URLs. These legacy values are intentionally no longer supported as part of the CodeQL alert 12 (`py/full-ssrf`) remediation.
 
 ---
 

--- a/app/auth.py
+++ b/app/auth.py
@@ -55,6 +55,10 @@ def hash_api_key(raw_key: str) -> str:
     return hmac.new(SECRET_KEY.encode(), raw_key.encode(), sha256).hexdigest()
 
 
+def legacy_hash_api_key(raw_key: str) -> str:
+    return sha256(raw_key.encode()).hexdigest()
+
+
 async def get_current_user(
     credentials: Optional[HTTPAuthorizationCredentials] = Depends(bearer),
     db: AsyncSession = Depends(get_db),
@@ -98,11 +102,13 @@ async def get_current_api_key(
     if not raw_key:
         raise exc
 
+    current_hash = hash_api_key(raw_key)
+    legacy_hash = legacy_hash_api_key(raw_key)
     result = await db.execute(
         select(APIKey, User)
         .join(User, User.id == APIKey.user_id)
         .where(
-            APIKey.key_hash == hash_api_key(raw_key),
+            APIKey.key_hash.in_([current_hash, legacy_hash]),
             APIKey.is_active == True,
             User.is_active == True,
         )
@@ -113,6 +119,8 @@ async def get_current_api_key(
         raise exc
 
     api_key, user = row
+    if hmac.compare_digest(api_key.key_hash, legacy_hash):
+        api_key.key_hash = current_hash
     api_key.last_used_at = datetime.now(timezone.utc)
     await db.commit()
     return api_key, user

--- a/app/auth.py
+++ b/app/auth.py
@@ -1,5 +1,6 @@
 import os
 import secrets
+import hmac
 from hashlib import sha256
 from datetime import datetime, timedelta, timezone
 from typing import Optional
@@ -51,7 +52,7 @@ def create_api_key() -> str:
 
 
 def hash_api_key(raw_key: str) -> str:
-    return sha256(raw_key.encode()).hexdigest()
+    return hmac.new(SECRET_KEY.encode(), raw_key.encode(), sha256).hexdigest()
 
 
 async def get_current_user(

--- a/app/main.py
+++ b/app/main.py
@@ -221,18 +221,11 @@ def _normalize_legacy_public_http_url(value: str) -> Optional[str]:
     if parsed.scheme != "http" or not host or parsed.username or parsed.password:
         return None
 
-    normalized_host = host.rstrip(".").lower()
-    if normalized_host == "localhost" or normalized_host.endswith(".local") or "." not in normalized_host:
-        return None
+    candidate = urlunparse(parsed._replace(scheme="https"))
     try:
-        ip = ipaddress.ip_address(normalized_host.strip("[]"))
-    except ValueError:
-        pass
-    else:
-        if not ip.is_global:
-            return None
-
-    return urlunparse(parsed._replace(scheme="https"))
+        return _validate_external_https_url(candidate, "base_url")
+    except HTTPException:
+        return None
 
 
 def _build_prompt_security_client(base_url: str, app_id: str) -> PromptSecurityClient:

--- a/app/main.py
+++ b/app/main.py
@@ -1,5 +1,6 @@
 import asyncio
 import base64
+import ipaddress
 import io
 import json
 import logging
@@ -11,6 +12,7 @@ from collections import defaultdict, deque
 from contextlib import asynccontextmanager
 from datetime import datetime, timezone
 from typing import Optional
+from urllib.parse import urlparse
 
 import httpx
 import openai
@@ -177,6 +179,32 @@ _FALLBACK_MODELS = [
 
 # ── Cached model list ─────────────────────────────────────────────────────────
 _model_cache: list[dict] = []
+
+
+def _validate_external_https_url(value: str, field_name: str) -> str:
+    url = (value or "").strip().rstrip("/")
+    parsed = urlparse(url)
+    host = parsed.hostname
+    if parsed.scheme != "https" or not host or parsed.username or parsed.password:
+        raise HTTPException(status_code=400, detail=f"{field_name} must be an https URL with a hostname")
+
+    normalized_host = host.rstrip(".").lower()
+    if normalized_host == "localhost" or normalized_host.endswith(".local"):
+        raise HTTPException(status_code=400, detail=f"{field_name} must not target local hosts")
+
+    try:
+        ip = ipaddress.ip_address(normalized_host.strip("[]"))
+    except ValueError:
+        return url
+    if not ip.is_global:
+        raise HTTPException(status_code=400, detail=f"{field_name} must not target private or reserved networks")
+    return url
+
+
+def _validate_optional_external_https_url(value: Optional[str], field_name: str) -> Optional[str]:
+    if value is None:
+        return None
+    return _validate_external_https_url(value, field_name)
 
 
 async def refresh_model_cache() -> list[dict]:
@@ -477,7 +505,8 @@ async def public_responses(
                 user=current_user.email,
             )
         except Exception as exc:
-            raise HTTPException(status_code=502, detail=f"Prompt Security scan failed: {exc}")
+            logger.error("Public API PS prompt scan error for %s: %s", current_user.email, exc)
+            raise HTTPException(status_code=502, detail="Prompt Security scan failed")
         if not ps_result.allowed:
             raise HTTPException(status_code=403, detail={"ps_action": "block", "violations": ps_result.violations})
         if ps_result.modified_text:
@@ -494,7 +523,7 @@ async def public_responses(
         )
     except Exception as exc:
         logger.error("Public API completion error: %s", exc)
-        raise HTTPException(status_code=502, detail=str(exc))
+        raise HTTPException(status_code=502, detail="Model request failed")
 
     text = _extract_response_text(resp)
     if not text:
@@ -509,7 +538,8 @@ async def public_responses(
                 user=current_user.email,
             )
         except Exception as exc:
-            raise HTTPException(status_code=502, detail=f"Prompt Security response scan failed: {exc}")
+            logger.error("Public API PS response scan error for %s: %s", current_user.email, exc)
+            raise HTTPException(status_code=502, detail="Prompt Security response scan failed")
         ps_violations = ps_resp.violations
         if not ps_resp.allowed:
             raise HTTPException(status_code=403, detail={"ps_action": "block", "violations": ps_violations})
@@ -732,7 +762,11 @@ async def admin_create_ps_tenant(
     existing = await db.scalar(select(PSTenant).where(PSTenant.name == body.name))
     if existing:
         raise HTTPException(status_code=409, detail="Tenant name already exists")
-    tenant = PSTenant(name=body.name, base_url=body.base_url, gateway_url=body.gateway_url)
+    tenant = PSTenant(
+        name=body.name,
+        base_url=_validate_external_https_url(body.base_url, "base_url"),
+        gateway_url=_validate_optional_external_https_url(body.gateway_url, "gateway_url"),
+    )
     db.add(tenant)
     await db.commit()
     await db.refresh(tenant)
@@ -753,9 +787,9 @@ async def admin_update_ps_tenant(
     if body.name is not None:
         tenant.name = body.name
     if body.base_url is not None:
-        tenant.base_url = body.base_url
+        tenant.base_url = _validate_external_https_url(body.base_url, "base_url")
     if body.gateway_url is not None:
-        tenant.gateway_url = body.gateway_url
+        tenant.gateway_url = _validate_optional_external_https_url(body.gateway_url, "gateway_url")
     await db.commit()
     await db.refresh(tenant)
     await _log_audit(db, admin.id, admin.email, "tenant_updated", f"{tenant.name}")
@@ -1103,12 +1137,12 @@ async def chat_stream(
             try:
                 if ps_mode == "api":
                     ps_client = PromptSecurityClient(
-                        base_url=current_user.ps_tenant.base_url,
+                        base_url=_validate_external_https_url(current_user.ps_tenant.base_url, "base_url"),
                         app_id=ps_app_id,
                     )
                 elif ps_mode == "gateway" and current_user.ps_tenant.gateway_url:
                     llm_key = _get_llm_key(current_user, model)
-                    gw_host = current_user.ps_tenant.gateway_url.rstrip('/')
+                    gw_host = _validate_external_https_url(current_user.ps_tenant.gateway_url, "gateway_url").rstrip('/')
                     gw_base = gw_host if gw_host.endswith('/v1') else gw_host + '/v1'
                     logger.info("PS gateway init for %s → %s model=%s (llm_key set: %s)",
                                 current_user.email, gw_base, model, bool(llm_key))
@@ -1133,6 +1167,8 @@ async def chat_stream(
                             )
                     else:
                         logger.warning("Gateway mode: no LLM key for %s — PS gateway requires the provider API key", current_user.email)
+            except HTTPException:
+                raise
             except Exception as e:
                 logger.warning("Could not init PS client for %s: %s", current_user.email, e)
 
@@ -1202,8 +1238,8 @@ async def chat_stream(
                         reply = text
                         yield f"data: {json.dumps({'type': 'token', 'content': text})}\n\n"
             except Exception as e:
-                detail = f"Gateway error: {e}"
-                logger.error(detail)
+                detail = "Gateway error"
+                logger.error("Gemini gateway error for %s: %s", current_user.email, e)
                 yield f"data: {json.dumps({'type': 'error', 'detail': detail})}\n\n"
                 return
             resp_ms = round((time.monotonic() - t0) * 1000)
@@ -1270,8 +1306,8 @@ async def chat_stream(
                                 u = event.get('usage', {})
                                 completion_tokens = u.get('output_tokens', 0)
             except Exception as e:
-                detail = f"Anthropic gateway error: {e}"
-                logger.error(detail)
+                detail = "Anthropic gateway error"
+                logger.error("Anthropic gateway error for %s: %s", current_user.email, e)
                 yield f"data: {json.dumps({'type': 'error', 'detail': detail})}\n\n"
                 return
             resp_ms = round((time.monotonic() - t0) * 1000)
@@ -1308,13 +1344,13 @@ async def chat_stream(
                                    ps_scanned=True, ps_blocked=True, ps_action="block")
                     yield f"data: {json.dumps({'type': 'blocked', 'action': 'block', 'violations': []})}\n\n"
                 else:
-                    detail = f"Gateway config error (400): {e}"
-                    logger.error(detail)
+                    detail = "Gateway config error"
+                    logger.error("PS gateway config error for %s: %s", current_user.email, e)
                     yield f"data: {json.dumps({'type': 'error', 'detail': detail})}\n\n"
                 return
             except openai.AuthenticationError as e:
-                detail = f"Gateway auth failed — check PS App ID: {e}"
-                logger.error(detail)
+                detail = "Gateway auth failed — check PS App ID."
+                logger.error("PS gateway auth failed for %s: %s", current_user.email, e)
                 yield f"data: {json.dumps({'type': 'error', 'detail': detail})}\n\n"
                 return
             except openai.PermissionDeniedError as e:
@@ -1325,11 +1361,11 @@ async def chat_stream(
                                    ps_scanned=True, ps_blocked=True, ps_action="block")
                     yield f"data: {json.dumps({'type': 'blocked', 'action': 'block', 'violations': []})}\n\n"
                 else:
-                    yield f"data: {json.dumps({'type': 'error', 'detail': f'Gateway permission denied: {e}'})}\n\n"
+                    yield f"data: {json.dumps({'type': 'error', 'detail': 'Gateway permission denied'})}\n\n"
                 return
             except Exception as e:
-                detail = f"Gateway error: {e}"
-                logger.error(detail)
+                detail = "Gateway error"
+                logger.error("PS gateway error for %s: %s", current_user.email, e)
                 yield f"data: {json.dumps({'type': 'error', 'detail': detail})}\n\n"
                 return
 
@@ -1377,7 +1413,7 @@ async def chat_stream(
             except Exception as e:
                 logger.error("PS prompt scan error for %s: %s", current_user.email, e)
                 err_hint = "PS App ID may be wrong for this tenant — re-enter it in ⚙ Settings → Prompt Security."
-                yield ("data: " + json.dumps({'type': 'error', 'detail': f'PS scan failed: {e}. {err_hint}'}) + "\n\n")
+                yield ("data: " + json.dumps({'type': 'error', 'detail': f'PS scan failed. {err_hint}'}) + "\n\n")
                 return
         else:
             last_user_msg_eff = last_user_msg
@@ -1403,7 +1439,7 @@ async def chat_stream(
                     yield f"data: {json.dumps({'type': 'token', 'content': token})}\n\n"
         except Exception as e:
             logger.error("LLM stream error: %s", e)
-            yield f"data: {json.dumps({'type': 'error', 'detail': str(e)})}\n\n"
+            yield f"data: {json.dumps({'type': 'error', 'detail': 'LLM stream failed'})}\n\n"
             return
 
         resp_ms = round((time.monotonic() - t0) * 1000)
@@ -1432,7 +1468,7 @@ async def chat_stream(
             except Exception as e:
                 logger.error("PS response scan error for %s: %s", current_user.email, e)
                 err_hint = "PS App ID may be wrong for this tenant — re-enter it in ⚙ Settings → Prompt Security."
-                yield ("data: " + json.dumps({'type': 'error', 'detail': f'PS response scan failed: {e}. {err_hint}'}) + "\n\n")
+                yield ("data: " + json.dumps({'type': 'error', 'detail': f'PS response scan failed. {err_hint}'}) + "\n\n")
                 return
 
         completion_tokens = completion_tokens or estimate_text_tokens(reply, model=effective_model)
@@ -1467,7 +1503,10 @@ async def upload_sanitize(
         ps_app_id = decrypt(current_user.ps_api_key_enc)
     except ValueError:
         raise HTTPException(status_code=400, detail="PS key could not be decrypted — re-enter it in Settings.")
-    ps_client = PromptSecurityClient(base_url=current_user.ps_tenant.base_url, app_id=ps_app_id)
+    ps_client = PromptSecurityClient(
+        base_url=_validate_external_https_url(current_user.ps_tenant.base_url, "base_url"),
+        app_id=ps_app_id,
+    )
     mime = (file.content_type or "application/octet-stream").split(";")[0].strip()
     filename = file.filename or "upload"
     if mime not in ALLOWED_SANITIZE_TYPES and not filename.lower().endswith(ALLOWED_SANITIZE_EXTENSIONS):
@@ -1492,10 +1531,11 @@ async def upload_sanitize(
             job_id = await ps_client.sanitize_file_submit(file_bytes, file.filename or "upload")
             result = await ps_client.sanitize_file_poll(job_id, max_seconds=30)
         except TimeoutError as e:
-            raise HTTPException(status_code=504, detail=str(e))
+            logger.error("File sanitization timeout for %s: %s", current_user.email, e)
+            raise HTTPException(status_code=504, detail="PS file sanitization timed out")
         except Exception as e:
             logger.error("File sanitization error for %s: %s", current_user.email, e)
-            raise HTTPException(status_code=502, detail=f"PS file sanitization failed: {e}")
+            raise HTTPException(status_code=502, detail="PS file sanitization failed")
         scan_ms = round((time.monotonic() - t0) * 1000)
         action = result.get("action", result.get("status", "pass"))
         violations = result.get("violations", [])
@@ -1578,7 +1618,8 @@ async def validate_llm_key(
                 else:
                     return {"valid": True, "provider": provider}  # non-401 likely means key is valid but other issue
         except Exception as e:
-            return {"valid": False, "provider": provider, "error": str(e)}
+            logger.warning("LLM key validation failed for %s/%s: %s", current_user.email, provider, e)
+            return {"valid": False, "provider": provider, "error": "Provider validation request failed"}
 
     url = urls.get(provider)
     if not url:
@@ -1597,7 +1638,8 @@ async def validate_llm_key(
             else:
                 return {"valid": False, "provider": provider, "error": f"HTTP {resp.status_code}"}
     except Exception as e:
-        return {"valid": False, "provider": provider, "error": str(e)}
+        logger.warning("LLM key validation failed for %s/%s: %s", current_user.email, provider, e)
+        return {"valid": False, "provider": provider, "error": "Provider validation request failed"}
 
 
 # ── Admin: Activity log ───────────────────────────────────────────────────────
@@ -1720,7 +1762,10 @@ def _build_ps_api_client(user: User) -> Optional[PromptSecurityClient]:
         return None
     if not ps_app_id:
         return None
-    return PromptSecurityClient(base_url=user.ps_tenant.base_url, app_id=ps_app_id)
+    return PromptSecurityClient(
+        base_url=_validate_external_https_url(user.ps_tenant.base_url, "base_url"),
+        app_id=ps_app_id,
+    )
 
 
 def _extract_response_text(resp) -> str:

--- a/app/main.py
+++ b/app/main.py
@@ -12,7 +12,7 @@ from collections import defaultdict, deque
 from contextlib import asynccontextmanager
 from datetime import datetime, timezone
 from typing import Optional
-from urllib.parse import urlparse
+from urllib.parse import urlparse, urlunparse
 
 import httpx
 import openai
@@ -135,7 +135,7 @@ def _model_meta(model_id: str) -> dict:
     return {
         "category": "free" if is_free else "paid",
         "provider": {"openai": "OpenAI", "anthropic": "Anthropic", "google": "Google", "perplexity": "Perplexity", "openrouter": "OpenRouter"}[provider],
-        "requires_key": None if is_free else provider,
+        "requires_key": provider,
     }
 
 
@@ -215,11 +215,69 @@ def _validate_optional_external_https_url(value: Optional[str], field_name: str)
     return _validate_external_https_url(value, field_name)
 
 
+def _normalize_legacy_public_http_url(value: str) -> Optional[str]:
+    parsed = urlparse((value or "").strip().rstrip("/"))
+    host = parsed.hostname
+    if parsed.scheme != "http" or not host or parsed.username or parsed.password:
+        return None
+
+    normalized_host = host.rstrip(".").lower()
+    if normalized_host == "localhost" or normalized_host.endswith(".local") or "." not in normalized_host:
+        return None
+    try:
+        ip = ipaddress.ip_address(normalized_host.strip("[]"))
+    except ValueError:
+        pass
+    else:
+        if not ip.is_global:
+            return None
+
+    return urlunparse(parsed._replace(scheme="https"))
+
+
 def _build_prompt_security_client(base_url: str, app_id: str) -> PromptSecurityClient:
     return PromptSecurityClient(
         base_url=_validate_external_https_url(base_url, "base_url"),
         app_id=app_id,
     )
+
+
+async def _migrate_legacy_ps_tenant_urls(db: AsyncSession) -> None:
+    result = await db.execute(select(PSTenant))
+    tenants = result.scalars().all()
+    changed = False
+    for tenant in tenants:
+        try:
+            _validate_external_https_url(tenant.base_url, "base_url")
+            continue
+        except HTTPException:
+            normalized = _normalize_legacy_public_http_url(tenant.base_url)
+            if normalized:
+                logger.warning(
+                    "Normalizing legacy PS tenant base_url tenant_id=%s from %s to %s",
+                    tenant.id,
+                    tenant.base_url,
+                    normalized,
+                )
+                tenant.base_url = normalized
+                changed = True
+                continue
+
+        users = (
+            await db.execute(select(User).where(User.ps_tenant_id == tenant.id, User.ps_enabled == True))
+        ).scalars().all()
+        if users:
+            logger.warning(
+                "Disabling PS for %d user(s) on legacy invalid PS tenant tenant_id=%s base_url=%s",
+                len(users),
+                tenant.id,
+                tenant.base_url,
+            )
+            for user in users:
+                user.ps_enabled = False
+            changed = True
+    if changed:
+        await db.commit()
 
 
 async def refresh_model_cache() -> list[dict]:
@@ -287,6 +345,7 @@ async def lifespan(app: FastAPI):
         await conn.run_sync(Base.metadata.create_all)
 
     async with AsyncSessionLocal() as db:
+        await _migrate_legacy_ps_tenant_urls(db)
         existing = await db.scalar(select(User).where(User.email == ADMIN_EMAIL))
         if not existing:
             admin = User(
@@ -1512,11 +1571,9 @@ async def upload_sanitize(
 ):
     if not (current_user.ps_enabled and current_user.ps_tenant and current_user.ps_api_key_enc):
         raise HTTPException(status_code=400, detail="Prompt Security is not configured. Set up PS in Settings first.")
-    try:
-        ps_app_id = decrypt(current_user.ps_api_key_enc)
-    except ValueError:
-        raise HTTPException(status_code=400, detail="PS key could not be decrypted — re-enter it in Settings.")
-    ps_client = _build_prompt_security_client(current_user.ps_tenant.base_url, ps_app_id)
+    ps_client = _build_ps_api_client(current_user)
+    if not ps_client:
+        raise HTTPException(status_code=400, detail="Prompt Security is not configured. Set up PS in Settings first.")
     mime = (file.content_type or "application/octet-stream").split(";")[0].strip()
     filename = file.filename or "upload"
     if mime not in ALLOWED_SANITIZE_TYPES and not filename.lower().endswith(ALLOWED_SANITIZE_EXTENSIONS):
@@ -1772,7 +1829,16 @@ def _build_ps_api_client(user: User) -> Optional[PromptSecurityClient]:
         return None
     if not ps_app_id:
         return None
-    return _build_prompt_security_client(user.ps_tenant.base_url, ps_app_id)
+    try:
+        return _build_prompt_security_client(user.ps_tenant.base_url, ps_app_id)
+    except HTTPException as exc:
+        logger.warning(
+            "Ignoring invalid persisted PS base_url for %s tenant_id=%s: %s",
+            _log_user_ref(user),
+            user.ps_tenant_id,
+            exc.detail,
+        )
+        return None
 
 
 def _extract_response_text(resp) -> str:

--- a/app/main.py
+++ b/app/main.py
@@ -135,6 +135,10 @@ def _model_meta(model_id: str) -> dict:
     }
 
 
+def _log_user_ref(user: User) -> str:
+    return f"user_id={getattr(user, 'id', 'unknown')}"
+
+
 def _get_llm_key(user: User, model_id: str) -> str:
     """Returns the best available API key for model_id: per-user → shared .env → empty."""
     provider = _detect_provider(model_id)
@@ -161,7 +165,7 @@ def _user_llm_client(user: User, model_id: str):
     if not key:
         return litellm_client, model_id
     base_url = _PROVIDER_URLS[provider]
-    logger.info("Using per-user %s key for %s", provider, user.email)
+    logger.info("Using per-user %s key for %s", provider, _log_user_ref(user))
     return AsyncOpenAI(api_key=key, base_url=base_url), model_id
 
 
@@ -205,6 +209,13 @@ def _validate_optional_external_https_url(value: Optional[str], field_name: str)
     if value is None:
         return None
     return _validate_external_https_url(value, field_name)
+
+
+def _build_prompt_security_client(base_url: str, app_id: str) -> PromptSecurityClient:
+    return PromptSecurityClient(
+        base_url=_validate_external_https_url(base_url, "base_url"),
+        app_id=app_id,
+    )
 
 
 async def refresh_model_cache() -> list[dict]:
@@ -505,7 +516,7 @@ async def public_responses(
                 user=current_user.email,
             )
         except Exception as exc:
-            logger.error("Public API PS prompt scan error for %s: %s", current_user.email, exc)
+            logger.error("Public API PS prompt scan error for %s: %s", _log_user_ref(current_user), exc)
             raise HTTPException(status_code=502, detail="Prompt Security scan failed")
         if not ps_result.allowed:
             raise HTTPException(status_code=403, detail={"ps_action": "block", "violations": ps_result.violations})
@@ -538,7 +549,7 @@ async def public_responses(
                 user=current_user.email,
             )
         except Exception as exc:
-            logger.error("Public API PS response scan error for %s: %s", current_user.email, exc)
+            logger.error("Public API PS response scan error for %s: %s", _log_user_ref(current_user), exc)
             raise HTTPException(status_code=502, detail="Prompt Security response scan failed")
         ps_violations = ps_resp.violations
         if not ps_resp.allowed:
@@ -1093,6 +1104,12 @@ async def chat_stream(
         raise HTTPException(status_code=400, detail="No user message found")
 
     system_prompt = request.system_prompt or "You are a helpful AI assistant."
+    user_ref = _log_user_ref(current_user)
+
+    # skip_ps is privileged: non-admin requests are explicitly rejected before any PS setup.
+    if request.skip_ps and current_user.role != "admin":
+        raise HTTPException(status_code=403, detail="skip_ps is restricted to admin users")
+    skip_ps = bool(request.skip_ps and current_user.role == "admin")
 
     # ── Daily limit check ─────────────────────────────────────────────────────
     today_start = datetime.now(timezone.utc).replace(hour=0, minute=0, second=0, microsecond=0)
@@ -1127,54 +1144,48 @@ async def chat_stream(
     ps_gw_gemini: Optional[dict]        = None    # gateway-mode config for Gemini (native path)
     ps_gw_anthropic: Optional[dict]     = None    # gateway-mode config for Anthropic (native path)
 
-    if current_user.ps_enabled and current_user.ps_tenant and current_user.ps_api_key_enc:
-        try:
-            ps_app_id = decrypt(current_user.ps_api_key_enc)
-        except ValueError:
-            logger.warning("PS key decrypt failed for %s — key rotated? Ask user to re-enter PS key.", current_user.email)
-            ps_app_id = None
-        if ps_app_id:
+    if not skip_ps and current_user.ps_enabled and current_user.ps_tenant and current_user.ps_api_key_enc:
+        if ps_mode == "api":
+            ps_client = _build_ps_api_client(current_user)
+        else:
             try:
-                if ps_mode == "api":
-                    ps_client = PromptSecurityClient(
-                        base_url=_validate_external_https_url(current_user.ps_tenant.base_url, "base_url"),
-                        app_id=ps_app_id,
-                    )
-                elif ps_mode == "gateway" and current_user.ps_tenant.gateway_url:
-                    llm_key = _get_llm_key(current_user, model)
-                    gw_host = _validate_external_https_url(current_user.ps_tenant.gateway_url, "gateway_url").rstrip('/')
-                    gw_base = gw_host if gw_host.endswith('/v1') else gw_host + '/v1'
-                    logger.info("PS gateway init for %s → %s model=%s (llm_key set: %s)",
-                                current_user.email, gw_base, model, bool(llm_key))
-                    ps_root = gw_host[:-3] if gw_host.endswith('/v1') else gw_host
-                    if llm_key:
-                        if model.startswith('gemini-'):
-                            gemini_url = f"{ps_root}/v1beta/models/{model}:generateContent"
-                            logger.info("PS Gemini gateway URL → %s", gemini_url)
-                            ps_gw_gemini = {'url': gemini_url, 'llm_key': llm_key}
-                        elif model.startswith('claude-'):
-                            anthropic_url = f"{ps_root}/v1/messages"
-                            logger.info("PS Anthropic gateway URL → %s model=%s", anthropic_url, model)
-                            ps_gw_anthropic = {'url': anthropic_url, 'llm_key': llm_key, 'model': model}
+                ps_app_id = decrypt(current_user.ps_api_key_enc)
+            except ValueError:
+                logger.warning("PS key decrypt failed for %s — key rotated? Ask user to re-enter PS key.", user_ref)
+                ps_app_id = None
+            if ps_app_id:
+                try:
+                    if ps_mode == "gateway" and current_user.ps_tenant.gateway_url:
+                        llm_key = _get_llm_key(current_user, model)
+                        gw_host = _validate_external_https_url(current_user.ps_tenant.gateway_url, "gateway_url").rstrip('/')
+                        gw_base = gw_host if gw_host.endswith('/v1') else gw_host + '/v1'
+                        logger.info("PS gateway init for %s → %s model=%s (llm_key set: %s)",
+                                    user_ref, gw_base, model, bool(llm_key))
+                        ps_root = gw_host[:-3] if gw_host.endswith('/v1') else gw_host
+                        if llm_key:
+                            if model.startswith('gemini-'):
+                                gemini_url = f"{ps_root}/v1beta/models/{model}:generateContent"
+                                logger.info("PS Gemini gateway URL → %s", gemini_url)
+                                ps_gw_gemini = {'url': gemini_url, 'llm_key': llm_key}
+                            elif model.startswith('claude-'):
+                                anthropic_url = f"{ps_root}/v1/messages"
+                                logger.info("PS Anthropic gateway URL → %s model=%s", anthropic_url, model)
+                                ps_gw_anthropic = {'url': anthropic_url, 'llm_key': llm_key, 'model': model}
+                            else:
+                                # PS routes OpenAI/Perplexity via LLM API key alone (OpenAI-compat)
+                                logger.info("PS gateway base_url → %s model=%s", gw_base, model)
+                                ps_gw_client = AsyncOpenAI(
+                                    api_key=llm_key,
+                                    base_url=gw_base,
+                                    timeout=30.0,
+                                    default_headers={"ps-user": current_user.email},
+                                )
                         else:
-                            # PS routes OpenAI/Perplexity via LLM API key alone (OpenAI-compat)
-                            logger.info("PS gateway base_url → %s model=%s", gw_base, model)
-                            ps_gw_client = AsyncOpenAI(
-                                api_key=llm_key,
-                                base_url=gw_base,
-                                timeout=30.0,
-                                default_headers={"ps-user": current_user.email},
-                            )
-                    else:
-                        logger.warning("Gateway mode: no LLM key for %s — PS gateway requires the provider API key", current_user.email)
-            except HTTPException:
-                raise
-            except Exception as e:
-                logger.warning("Could not init PS client for %s: %s", current_user.email, e)
-
-    # skip_ps is privileged: non-admin requests are explicitly rejected.
-    if request.skip_ps and current_user.role != "admin":
-        raise HTTPException(status_code=403, detail="skip_ps is restricted to admin users")
+                            logger.warning("Gateway mode: no LLM key for %s — PS gateway requires the provider API key", user_ref)
+                except HTTPException:
+                    raise
+                except Exception as e:
+                    logger.warning("Could not init PS client for %s: %s", user_ref, e)
 
     # ── Store user message in DB ──────────────────────────────────────────────
     user_db_msg = Message(
@@ -1186,8 +1197,6 @@ async def chat_stream(
     )
     db.add(user_db_msg)
     await db.commit()
-
-    skip_ps = request.skip_ps
 
     async def generate():
         reply = ""
@@ -1239,7 +1248,7 @@ async def chat_stream(
                         yield f"data: {json.dumps({'type': 'token', 'content': text})}\n\n"
             except Exception as e:
                 detail = "Gateway error"
-                logger.error("Gemini gateway error for %s: %s", current_user.email, e)
+                logger.error("Gemini gateway error for %s: %s", user_ref, e)
                 yield f"data: {json.dumps({'type': 'error', 'detail': detail})}\n\n"
                 return
             resp_ms = round((time.monotonic() - t0) * 1000)
@@ -1307,7 +1316,7 @@ async def chat_stream(
                                 completion_tokens = u.get('output_tokens', 0)
             except Exception as e:
                 detail = "Anthropic gateway error"
-                logger.error("Anthropic gateway error for %s: %s", current_user.email, e)
+                logger.error("Anthropic gateway error for %s: %s", user_ref, e)
                 yield f"data: {json.dumps({'type': 'error', 'detail': detail})}\n\n"
                 return
             resp_ms = round((time.monotonic() - t0) * 1000)
@@ -1345,12 +1354,12 @@ async def chat_stream(
                     yield f"data: {json.dumps({'type': 'blocked', 'action': 'block', 'violations': []})}\n\n"
                 else:
                     detail = "Gateway config error"
-                    logger.error("PS gateway config error for %s: %s", current_user.email, e)
+                    logger.error("PS gateway config error for %s: %s", user_ref, e)
                     yield f"data: {json.dumps({'type': 'error', 'detail': detail})}\n\n"
                 return
             except openai.AuthenticationError as e:
                 detail = "Gateway auth failed — check PS App ID."
-                logger.error("PS gateway auth failed for %s: %s", current_user.email, e)
+                logger.error("PS gateway auth failed for %s: %s", user_ref, e)
                 yield f"data: {json.dumps({'type': 'error', 'detail': detail})}\n\n"
                 return
             except openai.PermissionDeniedError as e:
@@ -1365,7 +1374,7 @@ async def chat_stream(
                 return
             except Exception as e:
                 detail = "Gateway error"
-                logger.error("PS gateway error for %s: %s", current_user.email, e)
+                logger.error("PS gateway error for %s: %s", user_ref, e)
                 yield f"data: {json.dumps({'type': 'error', 'detail': detail})}\n\n"
                 return
 
@@ -1385,7 +1394,7 @@ async def chat_stream(
             try:
                 prompt_tok_est = estimate_text_tokens(last_user_msg)
                 logger.info("PS prompt scan: user=%s, prompt_chars=%d, estimated_tokens=%d, prompt_preview=%.120s",
-                            current_user.email, len(last_user_msg), prompt_tok_est, last_user_msg)
+                            user_ref, len(last_user_msg), prompt_tok_est, last_user_msg)
                 ps_result = await ps_client.protect_prompt(
                     user_prompt=last_user_msg,
                     system_prompt=system_prompt,
@@ -1411,7 +1420,7 @@ async def chat_stream(
                 else:
                     last_user_msg_eff = last_user_msg
             except Exception as e:
-                logger.error("PS prompt scan error for %s: %s", current_user.email, e)
+                logger.error("PS prompt scan error for %s: %s", user_ref, e)
                 err_hint = "PS App ID may be wrong for this tenant — re-enter it in ⚙ Settings → Prompt Security."
                 yield ("data: " + json.dumps({'type': 'error', 'detail': f'PS scan failed. {err_hint}'}) + "\n\n")
                 return
@@ -1466,7 +1475,7 @@ async def chat_stream(
                     final_action = "modify"
                     yield f"data: {json.dumps({'type': 'sanitized', 'text': reply})}\n\n"
             except Exception as e:
-                logger.error("PS response scan error for %s: %s", current_user.email, e)
+                logger.error("PS response scan error for %s: %s", user_ref, e)
                 err_hint = "PS App ID may be wrong for this tenant — re-enter it in ⚙ Settings → Prompt Security."
                 yield ("data: " + json.dumps({'type': 'error', 'detail': f'PS response scan failed. {err_hint}'}) + "\n\n")
                 return
@@ -1503,10 +1512,7 @@ async def upload_sanitize(
         ps_app_id = decrypt(current_user.ps_api_key_enc)
     except ValueError:
         raise HTTPException(status_code=400, detail="PS key could not be decrypted — re-enter it in Settings.")
-    ps_client = PromptSecurityClient(
-        base_url=_validate_external_https_url(current_user.ps_tenant.base_url, "base_url"),
-        app_id=ps_app_id,
-    )
+    ps_client = _build_prompt_security_client(current_user.ps_tenant.base_url, ps_app_id)
     mime = (file.content_type or "application/octet-stream").split(";")[0].strip()
     filename = file.filename or "upload"
     if mime not in ALLOWED_SANITIZE_TYPES and not filename.lower().endswith(ALLOWED_SANITIZE_EXTENSIONS):
@@ -1531,10 +1537,10 @@ async def upload_sanitize(
             job_id = await ps_client.sanitize_file_submit(file_bytes, file.filename or "upload")
             result = await ps_client.sanitize_file_poll(job_id, max_seconds=30)
         except TimeoutError as e:
-            logger.error("File sanitization timeout for %s: %s", current_user.email, e)
+            logger.error("File sanitization timeout for %s: %s", _log_user_ref(current_user), e)
             raise HTTPException(status_code=504, detail="PS file sanitization timed out")
         except Exception as e:
-            logger.error("File sanitization error for %s: %s", current_user.email, e)
+            logger.error("File sanitization error for %s: %s", _log_user_ref(current_user), e)
             raise HTTPException(status_code=502, detail="PS file sanitization failed")
         scan_ms = round((time.monotonic() - t0) * 1000)
         action = result.get("action", result.get("status", "pass"))
@@ -1618,7 +1624,7 @@ async def validate_llm_key(
                 else:
                     return {"valid": True, "provider": provider}  # non-401 likely means key is valid but other issue
         except Exception as e:
-            logger.warning("LLM key validation failed for %s/%s: %s", current_user.email, provider, e)
+            logger.warning("LLM key validation failed for %s/%s: %s", _log_user_ref(current_user), provider, e)
             return {"valid": False, "provider": provider, "error": "Provider validation request failed"}
 
     url = urls.get(provider)
@@ -1638,7 +1644,7 @@ async def validate_llm_key(
             else:
                 return {"valid": False, "provider": provider, "error": f"HTTP {resp.status_code}"}
     except Exception as e:
-        logger.warning("LLM key validation failed for %s/%s: %s", current_user.email, provider, e)
+        logger.warning("LLM key validation failed for %s/%s: %s", _log_user_ref(current_user), provider, e)
         return {"valid": False, "provider": provider, "error": "Provider validation request failed"}
 
 
@@ -1758,14 +1764,11 @@ def _build_ps_api_client(user: User) -> Optional[PromptSecurityClient]:
     try:
         ps_app_id = decrypt(user.ps_api_key_enc)
     except ValueError:
-        logger.warning("PS key decrypt failed for %s", user.email)
+        logger.warning("PS key decrypt failed for %s", _log_user_ref(user))
         return None
     if not ps_app_id:
         return None
-    return PromptSecurityClient(
-        base_url=_validate_external_https_url(user.ps_tenant.base_url, "base_url"),
-        app_id=ps_app_id,
-    )
+    return _build_prompt_security_client(user.ps_tenant.base_url, ps_app_id)
 
 
 def _extract_response_text(resp) -> str:

--- a/app/main.py
+++ b/app/main.py
@@ -105,11 +105,14 @@ _PROVIDER_URLS = {
 
 
 _OLLAMA_MODEL_IDS = {s.strip() for s in os.getenv("OLLAMA_MODEL_IDS", "").split(",") if s.strip()}
+_LOCAL_OPENAI_MODEL_IDS = {s.strip() for s in os.getenv("LOCAL_OPENAI_MODEL_IDS", "").split(",") if s.strip()}
 
 
 def _detect_provider(model_id: str) -> str:
     if model_id in _OLLAMA_MODEL_IDS:
         return "ollama"
+    if model_id in _LOCAL_OPENAI_MODEL_IDS:
+        return "local_openai"
     m = model_id.lower()
     if m.startswith(("gpt-", "o1", "o3", "o4")):
         return "openai"
@@ -125,8 +128,9 @@ def _detect_provider(model_id: str) -> str:
 def _model_meta(model_id: str) -> dict:
     """Return category, provider, and required key info for a model."""
     provider = _detect_provider(model_id)
-    if provider == "ollama":
-        return {"category": "local", "provider": "Ollama", "requires_key": None}
+    if provider in {"ollama", "local_openai"}:
+        label = "Ollama" if provider == "ollama" else "Local OpenAI"
+        return {"category": "local", "provider": label, "requires_key": None}
     is_free = model_id.lower().endswith(":free")
     return {
         "category": "free" if is_free else "paid",

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from typing import Optional
 from uuid import UUID
-from pydantic import BaseModel, EmailStr
+from pydantic import BaseModel, EmailStr, Field
 
 
 # ── Auth ──────────────────────────────────────────────────────────────────────
@@ -34,15 +34,45 @@ class APIKeyCreateResponse(BaseModel):
 
 
 # ── PS Tenants ────────────────────────────────────────────────────────────────
+PS_BASE_URL_DESCRIPTION = (
+    "Prompt Security API base URL. Must be HTTPS, include a public hostname, "
+    "and must not target localhost, .local hosts, private IPs, or reserved networks."
+)
+PS_GATEWAY_URL_DESCRIPTION = (
+    "Optional Prompt Security gateway URL. Must be HTTPS, include a public hostname, "
+    "and must not target localhost, .local hosts, private IPs, or reserved networks."
+)
+
+
 class PSTenantCreate(BaseModel):
     name: str
-    base_url: str
-    gateway_url: Optional[str] = None
+    base_url: str = Field(
+        ...,
+        description=PS_BASE_URL_DESCRIPTION,
+        pattern=r"^https://",
+        examples=["https://api.prompt.security"],
+    )
+    gateway_url: Optional[str] = Field(
+        default=None,
+        description=PS_GATEWAY_URL_DESCRIPTION,
+        pattern=r"^https://",
+        examples=["https://gateway.prompt.security/v1"],
+    )
 
 class PSTenantUpdate(BaseModel):
     name: Optional[str] = None
-    base_url: Optional[str] = None
-    gateway_url: Optional[str] = None
+    base_url: Optional[str] = Field(
+        default=None,
+        description=PS_BASE_URL_DESCRIPTION,
+        pattern=r"^https://",
+        examples=["https://api.prompt.security"],
+    )
+    gateway_url: Optional[str] = Field(
+        default=None,
+        description=PS_GATEWAY_URL_DESCRIPTION,
+        pattern=r"^https://",
+        examples=["https://gateway.prompt.security/v1"],
+    )
 
 class PSTenantOut(BaseModel):
     id: int

--- a/app/static/admin.html
+++ b/app/static/admin.html
@@ -4,7 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Admin · AI Chat Demo</title>
-<script src="https://cdn.jsdelivr.net/npm/chart.js@4/dist/chart.umd.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.9/dist/chart.umd.min.js" integrity="sha384-b0GXujLkk9eYYSmcSfoyZbfyElGAQnDyY0skCHSG6w3JgTMFnz11ggrTAr7seu9f" crossorigin="anonymous"></script>
 <style>
 *,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
 :root{

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -2110,7 +2110,7 @@ reply = await client.chat.completions.create(
         const opt = document.createElement('option');
         opt.value = m.id;
         const provTag = m.provider ? ` [${m.provider}]` : '';
-        if (!m.key_set) {
+        if (m.requires_key && !m.key_set) {
           opt.textContent = m.id + provTag + ' (key required)';
           opt.disabled = true;
           opt.style.color = 'var(--text-muted)';

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -2034,8 +2034,9 @@ reply = await client.chat.completions.create(
       document.getElementById('adminSep').style.display = 'block';
       document.getElementById('adminPsLink').style.display = 'inline';
     }
+    updateCompareAvailability();
     updatePsStatus();
-    if (AUTH_USER?.ps_configured) enterCompareMode();
+    if (canUseCompareMode() && AUTH_USER?.ps_configured) enterCompareMode();
     await Promise.all([loadModels(), loadSessions(), loadStats()]);
     scheduleTokenEstimate();
   }
@@ -2059,7 +2060,7 @@ reply = await client.chat.completions.create(
       psStatusEl.title = 'Not configured — click ⚙ to set up';
       gear.className = '';
     }
-    if (AUTH_USER?.ps_configured && AUTH_USER?.ps_enabled && !compareModeActive) enterCompareMode();
+    if (canUseCompareMode() && AUTH_USER?.ps_configured && AUTH_USER?.ps_enabled && !compareModeActive) enterCompareMode();
   }
 
   async function quickTogglePs() {
@@ -2753,7 +2754,19 @@ reply = await client.chat.completions.create(
 
   const compareModeBtn = document.getElementById('compareModeBtn');
 
+  function canUseCompareMode() {
+    return AUTH_USER?.role === 'admin';
+  }
+
+  function updateCompareAvailability() {
+    const display = canUseCompareMode() ? '' : 'none';
+    compareModeBtn.style.display = display;
+    document.querySelectorAll('.demo-compare-btn').forEach(btn => { btn.style.display = display; });
+    if (!canUseCompareMode() && compareModeActive) exitCompare();
+  }
+
   function enterCompareMode() {
+    if (!canUseCompareMode()) return;
     compareModeActive = true;
     chatEl.style.display = 'none';
     compareColumns.classList.add('active');
@@ -2772,6 +2785,7 @@ reply = await client.chat.completions.create(
   }
   document.getElementById('cmpExitBtn').addEventListener('click', exitCompare);
   compareModeBtn.addEventListener('click', () => {
+    if (!canUseCompareMode()) return;
     if (compareModeActive) exitCompare(); else enterCompareMode();
   });
 
@@ -3576,12 +3590,13 @@ if (evt.type === 'done') {
   async function streamIntoBubble(bubble, footer, promptText, skipPs) {
     const model = document.getElementById('modelSelect').value || undefined;
     const sys = localStorage.getItem(SYS_KEY) || undefined;
+    const effectiveSkipPs = Boolean(skipPs && canUseCompareMode());
     const scrollContainer = bubble.closest('.cmp-messages') || bubble.closest('.compare-bubble')?.parentElement;
     const scrollBub = () => { if (scrollContainer) scrollContainer.scrollTop = scrollContainer.scrollHeight; };
     try {
       const res = await authFetch('/chat/stream', {
         method: 'POST',
-        body: JSON.stringify({ messages: [{ role: 'user', content: promptText }], model, skip_ps: skipPs }),
+        body: JSON.stringify({ messages: [{ role: 'user', content: promptText }], model, skip_ps: effectiveSkipPs }),
       });
       if (!res.ok) {
         bubble.textContent = `Error: ${res.statusText}`; return;
@@ -3640,6 +3655,7 @@ if (evt.type === 'done') {
   }
 
   function runCompare(promptText) {
+    if (!canUseCompareMode()) return;
     enterCompareMode();
     cmpLeftMsgs.innerHTML = '';
     cmpRightMsgs.innerHTML = '';

--- a/app/token_counter.py
+++ b/app/token_counter.py
@@ -20,7 +20,7 @@ def estimate_message_tokens(payload: list[dict[str, Any]], model: str | None = N
         count = token_counter(model=model or "", messages=_normalize_messages(payload))
         return max(int(count), 1)
     except Exception as exc:
-        logger.warning("LiteLLM token count failed for model %s: %s", model, exc)
+        logger.warning("LiteLLM message count failed for model %s (%s)", model, type(exc).__name__)
         return max(_fallback_estimate(payload), 1)
 
 
@@ -28,7 +28,7 @@ def estimate_text_tokens(text: str, model: str | None = None) -> int:
     try:
         return max(len(encode(model=model or "", text=text or "")), 1)
     except Exception as exc:
-        logger.warning("LiteLLM text token count failed for model %s: %s", model, exc)
+        logger.warning("LiteLLM text count failed for model %s (%s)", model, type(exc).__name__)
         return max((len(text or "") // 4) + 1, 1)
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,10 @@ services:
     ports:
       - "9000:8000"
     env_file: .env
+    environment:
+      LOCAL_OPENAI_BASE_URL: ${LOCAL_OPENAI_BASE_URL:-http://host.docker.internal:8081/v1}
+      LOCAL_OPENAI_API_KEY: ${LOCAL_OPENAI_API_KEY:-local-dev-key}
+      LOCAL_OPENAI_MODEL_IDS: ${LOCAL_OPENAI_MODEL_IDS:-huggingface/Qwen3VL-8B-Instruct-F16}
     depends_on:
       db:
         condition: service_healthy
@@ -30,13 +34,15 @@ services:
   litellm:
     image: ghcr.io/berriai/litellm:main-stable
     ports:
-      - "4000:4000"
+      - "${LITELLM_HOST_PORT:-4000}:4000"
     volumes:
       - ./litellm/config.yaml:/app/config.yaml
     env_file: .env
     environment:
       DATABASE_URL: "postgresql://hgapp:${POSTGRES_PASSWORD:-hgapp_dev}@db:5432/litellm"
       PYTHONHTTPSVERIFY: "0"
+      LOCAL_OPENAI_BASE_URL: ${LOCAL_OPENAI_BASE_URL:-http://host.docker.internal:8081/v1}
+      LOCAL_OPENAI_API_KEY: ${LOCAL_OPENAI_API_KEY:-local-dev-key}
     command: ["--config", "/app/config.yaml", "--port", "4000", "--num_workers", "1"]
     restart: unless-stopped
 

--- a/litellm/config.yaml
+++ b/litellm/config.yaml
@@ -129,6 +129,14 @@ model_list:
       model: ollama/gemma3:270m
       api_base: os.environ/OLLAMA_BASE_URL
 
+  # ── Local OpenAI-compatible endpoint ─────────────────────────────────────
+  # Default test target: llama.cpp / OpenAI-style server on the host at :8081.
+  - model_name: huggingface/Qwen3VL-8B-Instruct-F16
+    litellm_params:
+      model: openai/huggingface/Qwen3VL-8B-Instruct-F16
+      api_base: os.environ/LOCAL_OPENAI_BASE_URL
+      api_key: os.environ/LOCAL_OPENAI_API_KEY
+
 litellm_settings:
   drop_params: true
   request_timeout: 60

--- a/tests/test_app_endpoints.py
+++ b/tests/test_app_endpoints.py
@@ -475,6 +475,9 @@ async def test_chat_stream_non_admin_cannot_bypass_ps_with_skip_flag(client, db,
 
 @pytest.mark.asyncio
 async def test_chat_stream_admin_can_bypass_ps_with_skip_flag(client, db, test_tenant):
+    test_tenant.base_url = "http://localhost"
+    await db.commit()
+
     admin = User(
         email="admin-skip@test.com",
         hashed_password=hash_password("password"),

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -59,7 +59,7 @@ def test_model_meta_free():
     meta = _model_meta("meta-llama/llama-3.1-8b-instruct:free")
     assert meta["category"] == "free"
     assert meta["provider"] == "OpenRouter"
-    assert meta["requires_key"] is None
+    assert meta["requires_key"] == "openrouter"
 
 
 def test_model_meta_paid_openai():
@@ -104,4 +104,4 @@ def test_free_suffix_detection():
     ]:
         meta = _model_meta(model_id)
         assert meta["category"] == "free", f"{model_id} should be free"
-        assert meta["requires_key"] is None, f"{model_id} should not require key"
+        assert meta["requires_key"] == "openrouter", f"{model_id} should require OpenRouter key"

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -40,6 +40,20 @@ def test_detect_provider_openrouter_default():
     assert _detect_provider("mistralai/mistral-7b-instruct:free") == "openrouter"
 
 
+def test_local_openai_model_metadata(monkeypatch):
+    import main
+
+    model_id = "huggingface/Qwen3VL-8B-Instruct-F16"
+    monkeypatch.setattr(main, "_LOCAL_OPENAI_MODEL_IDS", {model_id})
+
+    assert main._detect_provider(model_id) == "local_openai"
+    assert main._model_meta(model_id) == {
+        "category": "local",
+        "provider": "Local OpenAI",
+        "requires_key": None,
+    }
+
+
 def test_model_meta_free():
     from main import _model_meta
     meta = _model_meta("meta-llama/llama-3.1-8b-instruct:free")

--- a/tests/test_security_hardening.py
+++ b/tests/test_security_hardening.py
@@ -63,6 +63,14 @@ def test_frontend_only_disables_models_that_require_missing_keys():
     assert "if (m.requires_key && !m.key_set)" in html
 
 
+def test_frontend_gates_compare_mode_to_admins():
+    html = (REPO_ROOT / "app/static/index.html").read_text(encoding="utf-8")
+
+    assert "function canUseCompareMode()" in html
+    assert "AUTH_USER?.role === 'admin'" in html
+    assert "const effectiveSkipPs = Boolean(skipPs && canUseCompareMode());" in html
+
+
 def test_dockerfile_uses_non_root_runtime_user():
     dockerfile = (REPO_ROOT / "Dockerfile").read_text(encoding="utf-8")
 
@@ -127,3 +135,40 @@ def test_external_url_validation_allows_https_hostnames():
         main._validate_external_https_url("https://test.prompt.security/v1", "gateway_url")
         == "https://test.prompt.security/v1"
     )
+
+
+def test_legacy_public_http_url_can_be_normalized():
+    import main
+
+    assert main._normalize_legacy_public_http_url("http://test.prompt.security/api") == "https://test.prompt.security/api"
+    assert main._normalize_legacy_public_http_url("http://localhost/api") is None
+    assert main._normalize_legacy_public_http_url("http://10.0.0.1/api") is None
+
+
+@pytest.mark.asyncio
+async def test_invalid_persisted_ps_base_url_soft_fails(db, test_user, test_tenant):
+    import main
+    from crypto import encrypt
+
+    test_tenant.base_url = "http://localhost"
+    test_user.ps_tenant_id = test_tenant.id
+    test_user.ps_tenant = test_tenant
+    test_user.ps_api_key_enc = encrypt("app-id")
+    test_user.ps_enabled = True
+
+    assert main._build_ps_api_client(test_user) is None
+
+
+@pytest.mark.asyncio
+async def test_legacy_invalid_ps_tenant_disables_existing_users(db, test_user, test_tenant):
+    import main
+
+    test_tenant.base_url = "http://localhost"
+    test_user.ps_tenant_id = test_tenant.id
+    test_user.ps_enabled = True
+    await db.commit()
+
+    await main._migrate_legacy_ps_tenant_urls(db)
+    await db.refresh(test_user)
+
+    assert test_user.ps_enabled is False

--- a/tests/test_security_hardening.py
+++ b/tests/test_security_hardening.py
@@ -1,8 +1,21 @@
 """Security hardening regression tests."""
 
+import os
+from hashlib import sha256
 from pathlib import Path
 
 import pytest
+from fastapi import HTTPException
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+@pytest.fixture(autouse=True)
+def _chdir_to_app():
+    original = os.getcwd()
+    os.chdir(REPO_ROOT / "app")
+    yield
+    os.chdir(original)
 
 
 def test_validate_security_bootstrap_config_rejects_insecure_defaults(monkeypatch):
@@ -27,9 +40,57 @@ def test_validate_security_bootstrap_config_allows_secure_values(monkeypatch):
 
 
 def test_frontend_uses_dompurify_for_markdown_rendering():
-    html = Path("app/static/index.html").read_text(encoding="utf-8")
+    html = (REPO_ROOT / "app/static/index.html").read_text(encoding="utf-8")
 
     assert "dompurify" in html.lower()
     assert "function sanitizeHtml(" in html
     assert "DOMPurify.sanitize" in html
     assert "bub.innerHTML = sanitizeHtml(rawHtml);" in html
+
+
+def test_admin_chart_script_is_pinned_with_sri():
+    html = (REPO_ROOT / "app/static/admin.html").read_text(encoding="utf-8")
+
+    assert "chart.js@4.4.9" in html
+    assert 'integrity="sha384-' in html
+    assert 'crossorigin="anonymous"' in html
+
+
+def test_dockerfile_uses_non_root_runtime_user():
+    dockerfile = (REPO_ROOT / "Dockerfile").read_text(encoding="utf-8")
+
+    assert "\nUSER appuser\n" in dockerfile
+
+
+def test_api_key_hash_is_keyed():
+    from auth import hash_api_key
+
+    raw_key = "hg_live_example"
+    assert hash_api_key(raw_key) == hash_api_key(raw_key)
+    assert hash_api_key(raw_key) != sha256(raw_key.encode()).hexdigest()
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://prompt.security",
+        "https://localhost",
+        "https://127.0.0.1",
+        "https://10.0.0.1",
+        "https://169.254.169.254",
+    ],
+)
+def test_external_url_validation_rejects_unsafe_targets(url):
+    import main
+
+    with pytest.raises(HTTPException):
+        main._validate_external_https_url(url, "gateway_url")
+
+
+def test_external_url_validation_allows_https_hostnames():
+    import main
+
+    assert (
+        main._validate_external_https_url("https://test.prompt.security/v1", "gateway_url")
+        == "https://test.prompt.security/v1"
+    )

--- a/tests/test_security_hardening.py
+++ b/tests/test_security_hardening.py
@@ -71,6 +71,27 @@ def test_frontend_gates_compare_mode_to_admins():
     assert "const effectiveSkipPs = Boolean(skipPs && canUseCompareMode());" in html
 
 
+def test_ps_tenant_schema_documents_https_public_host_contract():
+    from schemas import PSTenantCreate, PSTenantUpdate
+
+    def string_schema(prop: dict) -> dict:
+        if "anyOf" not in prop:
+            return prop
+        return next(item for item in prop["anyOf"] if item.get("type") == "string")
+
+    create_schema = PSTenantCreate.model_json_schema()
+    update_schema = PSTenantUpdate.model_json_schema()
+
+    for schema in (create_schema, update_schema):
+        base_url = schema["properties"]["base_url"]
+        assert "private IPs" in base_url["description"]
+        assert string_schema(base_url)["pattern"] == "^https://"
+
+        gateway_url = schema["properties"]["gateway_url"]
+        assert "localhost" in gateway_url["description"]
+        assert string_schema(gateway_url)["pattern"] == "^https://"
+
+
 def test_dockerfile_uses_non_root_runtime_user():
     dockerfile = (REPO_ROOT / "Dockerfile").read_text(encoding="utf-8")
 

--- a/tests/test_security_hardening.py
+++ b/tests/test_security_hardening.py
@@ -1,6 +1,7 @@
 """Security hardening regression tests."""
 
 import os
+from types import SimpleNamespace
 from hashlib import sha256
 from pathlib import Path
 
@@ -68,6 +69,32 @@ def test_api_key_hash_is_keyed():
     raw_key = "hg_live_example"
     assert hash_api_key(raw_key) == hash_api_key(raw_key)
     assert hash_api_key(raw_key) != sha256(raw_key.encode()).hexdigest()
+
+
+@pytest.mark.asyncio
+async def test_legacy_api_key_hash_is_accepted_and_migrated(db, test_user):
+    from auth import get_current_api_key, hash_api_key
+    from models import APIKey
+
+    raw_key = "hg_live_legacy_example"
+    key = APIKey(
+        user_id=test_user.id,
+        name="legacy",
+        key_hash=sha256(raw_key.encode()).hexdigest(),
+        key_prefix="hg_live_",
+        is_active=True,
+    )
+    db.add(key)
+    await db.commit()
+    await db.refresh(key)
+
+    request = SimpleNamespace(headers={"authorization": f"Bearer {raw_key}"})
+    api_key, user = await get_current_api_key(request, db)
+
+    assert api_key.id == key.id
+    assert user.id == test_user.id
+    assert api_key.key_hash == hash_api_key(raw_key)
+    assert api_key.key_hash != sha256(raw_key.encode()).hexdigest()
 
 
 @pytest.mark.parametrize(

--- a/tests/test_security_hardening.py
+++ b/tests/test_security_hardening.py
@@ -57,6 +57,12 @@ def test_admin_chart_script_is_pinned_with_sri():
     assert 'crossorigin="anonymous"' in html
 
 
+def test_frontend_only_disables_models_that_require_missing_keys():
+    html = (REPO_ROOT / "app/static/index.html").read_text(encoding="utf-8")
+
+    assert "if (m.requires_key && !m.key_set)" in html
+
+
 def test_dockerfile_uses_non_root_runtime_user():
     dockerfile = (REPO_ROOT / "Dockerfile").read_text(encoding="utf-8")
 


### PR DESCRIPTION
# User description
## Summary

- Add the repo-local Codex skill and helper script for managing the HomeGrown AI App Demo Docker stack.
- Remediate GitHub code-scanning findings, including the CodeQL `py/full-ssrf` alert on Prompt Security gateway URLs, raw exception exposure, API-key hashing, sensitive logging, CDN integrity, token-count logging, and non-root container runtime.
- Address Baz review follow-ups for PII-safe logging, `skip_ps` ordering, shared Prompt Security client construction, and legacy API-key hash compatibility.
- Add local OpenAI-compatible inference support through LiteLLM for `huggingface/Qwen3VL-8B-Instruct-F16`.
- Make the LiteLLM host port configurable for local environments where host port `4000` is already occupied.
- Fix the model selector so local models remain selectable when they do not require a provider API key.
- Expand regression coverage, docs, and changelog entries for the security hardening, local inference, and UI testing scope.

## Extended Scope From Testing

During PR validation, we added a real local inference path so the app can be tested end to end against a host OpenAI-compatible server on `localhost:8081`, reached from Docker as `host.docker.internal`.

This added:

- `LOCAL_OPENAI_BASE_URL`
- `LOCAL_OPENAI_API_KEY`
- `LOCAL_OPENAI_MODEL_IDS`
- `LITELLM_HOST_PORT`
- A LiteLLM model entry for the local OpenAI-compatible model
- App metadata support for `Local OpenAI` models
- UI and regression coverage for local model key handling

## Security Scope

- Validate Prompt Security tenant `base_url` and `gateway_url` values as external HTTPS URLs before they can feed Prompt Security API clients or gateway requests.
- Reject local, private, reserved, credentialed, or non-HTTPS Prompt Security URLs.
- Replace unsalted SHA-256 public API-key hashing with `SECRET_KEY`-keyed HMAC hashing while accepting and lazily migrating legacy hashes.
- Avoid returning raw upstream exception text to clients in public API and Prompt Security failure paths.
- Avoid logging user email addresses in security-sensitive error paths where an internal user reference is enough.
- Gate `skip_ps` to admins before Prompt Security setup and validation work begins.
- Pin the admin Chart.js CDN asset with SRI.
- Run the app container as the non-root `appuser`.
- Add regression coverage for the hardened paths.

## Test Plan

- `git diff --check` - passed
- `docker compose config -q` - passed
- `/tmp/homegrown-test-venv/bin/python -m pytest -q` - `115 passed, 1 warning`
- `docker compose ps` - `app`, `db`, and `litellm` running; DB healthy
- `GET /health` - `status=ok`, `models_loaded=25`
- Direct local inference `/v1/models` - local model found
- App auth using local admin credentials - passed
- `POST /admin/refresh-models` - `25` models loaded
- `GET /models` - local model listed as `Local OpenAI`, `requires_key=null`
- `POST /chat/token-estimate` - passed
- `POST /chat/stream` with Prompt Security enabled - harmless prompt passed with `ps_scanned=true`, `ps_action=pass`
- `POST /chat/stream` with Prompt Security enabled - injection-style prompt blocked with `Prompt Injection Engine`
- `POST /chat/stream` with admin `skip_ps=true` - raw local model path passed with `ps_scanned=false`
- Browser UI compare mode - PS pane showed `ALLOWED` / `PS: pass`; raw pane also returned the expected local model response
- GitHub checks - CI, lint, CodeQL, Semgrep, Trivy, gitleaks, pip-audit, dependency-review, and Baz Reviewer passing

## Compatibility Notes

- Existing app-issued public API keys using the legacy SHA-256 hash format are still accepted and are lazily migrated to the new `SECRET_KEY`-keyed HMAC hash on successful authentication.
- Prompt Security tenant and App ID configuration still lives in the app database and is managed through the web UI/API, not `.env`.
- `.env` remains gitignored; provider keys, Prompt Security App IDs, and local secrets are not committed.
- Local OpenAI-compatible endpoint values are documented in `.env.example` and can be overridden per developer environment.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Document the repo-local Codex skill and helper script while describing the new LiteLLM/OpenAI-compatible tooling for managing the Docker stack. Harden the FastAPI app’s Prompt Security, API-key, and logging flows as well as its runtime configuration and tests to keep public and admin paths resilient.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/prompt-security/homegrown-ai-app-demo/7?tool=ast&topic=Prompt+Security>Prompt Security</a>
        </td><td>Harden Prompt Security, authentication, and observability by validating HTTPS tenant URLs, gating admin bypass, logging only PS-safe references, keying API hashes, sanitizing gateway client construction, and expanding regression tests plus CDN integrity checks and token-counter warnings.<details><summary>Modified files (8)</summary><ul><li>app/auth.py</li>
<li>app/main.py</li>
<li>app/schemas.py</li>
<li>app/static/admin.html</li>
<li>app/static/index.html</li>
<li>app/token_counter.py</li>
<li>tests/test_app_endpoints.py</li>
<li>tests/test_security_hardening.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>David.a@prompt.security</td><td>docs: document PS tena...</td><td>May 04, 2026</td></tr>
<tr><td>ori.tabac@sentinelone.com</td><td>fix: respect skip_ps i...</td><td>April 26, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/prompt-security/homegrown-ai-app-demo/7?tool=ast&topic=Local+Inference>Local Inference</a>
        </td><td>Enable and document local OpenAI-compatible inference (including LiteLLM host customization), keep Local models selectable when they don’t need provider keys, and bundle the Codex skill/script plus docs/changelog coverage for managing the HomeGrown AI App Demo stack.<details><summary>Modified files (9)</summary><ul><li>.codex/skills/homegrown-ai-app-demo/SKILL.md</li>
<li>.codex/skills/homegrown-ai-app-demo/scripts/manage.sh</li>
<li>.env.example</li>
<li>CHANGELOG.md</li>
<li>Dockerfile</li>
<li>README.md</li>
<li>docker-compose.yml</li>
<li>litellm/config.yaml</li>
<li>tests/test_models.py</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>David.a@prompt.security</td><td>feat: support local Op...</td><td>May 04, 2026</td></tr>
<tr><td>ori.tabac@sentinelone.com</td><td>feat: add gemma3:270m ...</td><td>April 26, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/prompt-security/homegrown-ai-app-demo/7?tool=ast&topic=Other>Other</a>
        </td><td>Other files<details><summary>Modified files (1)</summary><ul><li>.codex/skills/homegrown-ai-app-demo/agents/openai.yaml</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>David.a@prompt.security</td><td>docs: add shared Codex...</td><td>May 04, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/prompt-security/homegrown-ai-app-demo/7?tool=ast>(Baz)</a>.