### PR TITLE
Remove Singapore Mandarin translation (English-only)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [2026-06-17]
+### Changed
+- Singapore (`pii_SG`) is now English-only — removed Mandarin (`prompt_zh`) translation and language picker; Singapore's primary working language is English, and Simplified Chinese differs from Traditional Chinese (Taiwan) — @ori.tabac
+- Added multilang translations to `injection` and `injSoft` scenarios: Hindi, Hebrew, Mandarin, German, Portuguese, Malay (Japanese was already present); injection tests restructured to parametrize over all 8 languages — @ori.tabac
+- CLAUDE.md language table updated: `zh` row removed, note added clarifying SG English-only and Indonesia (`id`) vs Malaysia (`ms`) distinction — @ori.tabac
+
 ## [2026-06-15]
 ### Fixed
 - PS API tests now return `action=modify` for PII: isolated each test to a single detector (PII tests enable only Sensitive Data; injection tests enable only Prompt Injection Engine); previously the full policy's Data Privacy Guidelines, Natural Language Guardrails, and Topics Detector fired on financial/HR content in test prompts and returned `action=block` instead of `action=modify` — @ori.tabac

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,14 +93,15 @@ The demo panel supports multi-language PII prompts via a language picker (`<sele
 
 | Code | Language | Countries |
 |---|---|---|
-| `en` | English | All |
+| `en` | English | All (US, AU, GB, SG are English-only — no picker shown) |
 | `hi` | हिन्दी | IN |
 | `he` | עברית | IL |
-| `zh` | 中文 | SG |
 | `de` | Deutsch | DE |
 | `ja` | 日本語 | JP |
 | `pt` | Português | BR |
 | `ms` | Bahasa Malaysia | MY |
+
+**Note:** Singapore (`pii_SG`) is English-only. Though Mandarin is spoken in Singapore, the primary working language is English and Simplified Chinese differs from Traditional Chinese (used in Taiwan). No `zh` picker is shown for SG. If Indonesia is ever added, use `id` (Indonesian) — distinct from Bahasa Malaysia (`ms`).
 
 ### Adding a translation to an existing country
 

--- a/app/data/scenarios.json
+++ b/app/data/scenarios.json
@@ -68,8 +68,7 @@
     "meta": {
       "country_code": "SG",
       "country_name": "Singapore",
-      "flag": "🇸🇬",
-      "prompt_zh": "请发送确认邮件至hr@prompt.security，关于新员工陈伟明的入职手续。他的身份证号码（NRIC）为S1234567D，电话：+65 9123 4567。"
+      "flag": "🇸🇬"
     },
     "prompt": "Write a confirmation email to hr@prompt.security for the new hire Tan Wei Ming. His NRIC number is S1234567D, phone number is +65 9123 4567, and email address is weiming.tan@grab.com. Include all details in the onboarding summary."
   },

--- a/app/data/translations.py
+++ b/app/data/translations.py
@@ -24,8 +24,7 @@ SCENARIO_TRANSLATIONS: dict[str, dict[str, str]] = {
     "pii_IN": {"lang": "hi"},
     # Israel — Hebrew
     "pii_IL": {"lang": "he"},
-    # Singapore — Mandarin
-    "pii_SG": {"lang": "zh"},
+    # Singapore — English-only (primary working language is English; no native picker shown)
     # Germany — German
     "pii_DE": {"lang": "de"},
     # Japan — Japanese

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -4370,9 +4370,6 @@ reply = await client.chat.completions.create(
     pii_IL: {
       prompt_he: 'כתוב מייל ל-transfer@prompt.security לבקש העברת 10K דולר לחשבון IBAN מספר IL520108350000000012345 עבור רכישת GPU של יעל כהן. מספר תעודת הזהות שלה: 329745814, טלפון: +972 52-345-6789.',
     },
-    pii_SG: {
-      prompt_zh: '请发送确认邮件至hr@prompt.security，关于新员工陈伟明的入职手续。他的身份证号码（NRIC）为S1234567D，电话：+65 9123 4567。',
-    },
     pii_DE: {
       prompt_de: 'Bitte senden Sie eine E-Mail an compliance@prompt.security zur KYC-Verifizierung von Hans Mueller. Personalausweisnummer: T220001293, Reisepassnummer: C01X00T41, Telefonnummer: +49 170 1234567.',
     },

--- a/tests/test_pii_translations.py
+++ b/tests/test_pii_translations.py
@@ -74,7 +74,7 @@ COUNTRY_ENTITIES = {
     ],
     "IN": ["INDIA_AADHAAR_NUMBER", "INDIA_PAN_NUMBER"],
     "IL": ["IL_ID_NUMBER", "IL_PASSPORT_RE", "IL_BANK_NUMBER", "IBAN_CODE"],
-    "SG": ["SG_NRIC_FIN", "SINGAPORE_PASSPORT_NUMBER", "SINGAPORE_DRIVER_LICENSE_NUMBER"],
+    "SG": ["SG_NRIC_FIN", "SINGAPORE_PASSPORT_NUMBER", "SINGAPORE_DRIVER_LICENSE_NUMBER"],  # English-only, no native lang picker
     "BR": ["BR_CPF_NUMBER", "BRAZIL_CNPJ_NUMBER"],
     "MY": ["MALAYSIA_ID_NUMBER"],
 }
@@ -165,8 +165,7 @@ _INJ_LANGS = ["ja", "hi", "he", "zh", "de", "pt", "ms"]
 def _registered_translations():
     pairs = {
         ("pii_JP", "ja"), ("pii_DE", "de"), ("pii_IN", "hi"),
-        ("pii_IL", "he"), ("pii_SG", "zh"), ("pii_BR", "pt"),
-        ("pii_MY", "ms"),
+        ("pii_IL", "he"), ("pii_BR", "pt"), ("pii_MY", "ms"),
     }
     for lang in _INJ_LANGS:
         pairs.add(("injection", lang))
@@ -261,16 +260,10 @@ async def test_pii_israel_hebrew(ps_client, scenarios, base_policy):
 
 @pytest.mark.asyncio
 async def test_pii_singapore_english(ps_client, scenarios, base_policy):
+    # Singapore is English-only — no native language picker (primary working language is English)
     policy = _pii_policy(base_policy, "SG")
     detected = await _assert_pii_modify(ps_client, scenarios, "pii_SG", "en", policy)
     print(f"\npii_SG/en detected: {detected}")
-
-
-@pytest.mark.asyncio
-async def test_pii_singapore_mandarin(ps_client, scenarios, base_policy):
-    policy = _pii_policy(base_policy, "SG")
-    detected = await _assert_pii_modify(ps_client, scenarios, "pii_SG", "zh", policy)
-    print(f"\npii_SG/zh detected: {detected}")
 
 
 # ── Brazil ────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- `pii_SG` is now English-only — removed `prompt_zh` (Mandarin) from `scenarios.json`, `index.html` `_SCENARIO_TRANSLATIONS`, `translations.py`, and tests
- Singapore's primary working language is English; Simplified Chinese (SG) differs from Traditional Chinese (TW)
- CLAUDE.md updated: SG English-only noted, future Indonesia scenario should use `id` not `ms` (Bahasa Indonesia ≠ Bahasa Malaysia)

## Test plan
- [ ] `test_pii_singapore_mandarin` removed — coverage guard still passes
- [ ] `test_pii_singapore_english` still present and passes
- [ ] No language picker shown on Singapore PII card in demo

🤖 Generated with [Claude Code](https://claude.ai/claude-code)